### PR TITLE
[Feat] ID/PW 로그인 시 JWT 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,17 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // 스프링독 추가(스웨거 사용 위함)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/wanted/moneyway/base/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.wanted.moneyway.base.config;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+
+@OpenAPIDefinition(
+        info = @Info(title = "moneyway",
+                version = "v1")
+)
+@Configuration
+@SecurityScheme(
+	name = "bearerAuth",
+	type = SecuritySchemeType.HTTP,
+	bearerFormat = "JWT",
+	scheme = "bearer"
+)
+@SecurityScheme(
+	name = "refreshToken",
+	type = SecuritySchemeType.APIKEY,
+	in = SecuritySchemeIn.HEADER,
+	paramName = "X-Refresh-Token"
+)
+public class SwaggerConfig {
+}

--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -1,0 +1,42 @@
+package com.wanted.moneyway.base.initData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.repository.MemberRepository;
+
+@Configuration
+@Profile({"dev", "test"})
+public class NotProd {
+	@Bean
+	CommandLineRunner initData(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+		return args -> {
+			String password = passwordEncoder.encode("1234");
+			List<Member> memberList = new ArrayList<>();
+			Member user1 = Member.builder()
+				.userName("user1")
+				.password(password)
+				.build();
+
+			Member user2 = Member.builder()
+				.userName("user2")
+				.password(password)
+				.build();
+
+			Member user3 = Member.builder()
+				.userName("user3")
+				.password(password)
+				.build();
+
+			memberList.addAll(List.of(user1, user2, user3));
+			memberRepository.saveAll(memberList);
+		};
+	}
+}

--- a/src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java
+++ b/src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java
@@ -1,0 +1,82 @@
+package com.wanted.moneyway.base.jwt;
+
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.wanted.moneyway.standard.util.Ut;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtProvider {
+	private SecretKey cachedSecretKey;
+
+	@Value("${custom.jwt.secretKey}")
+	private String secretKeyPlain;
+
+	private SecretKey _getSecretKey() {
+		String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKeyPlain.getBytes());
+		return Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+	}
+
+	public SecretKey getSecretKey() {
+		if (cachedSecretKey == null)
+			cachedSecretKey = _getSecretKey();
+
+		return cachedSecretKey;
+	}
+
+	public String genAccessToken(Map<String, Object> claims, int seconds) {
+		long now = new Date().getTime();
+		Date accessTokenExpiresIn = new Date(now + 1000L * seconds);
+
+		return Jwts.builder()
+			.claim("body", Ut.json.toStr(claims))
+			.setExpiration(accessTokenExpiresIn)
+			.signWith(getSecretKey(), SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public String genToken(Map<String, Object> claims, int seconds) {
+		long now = new Date().getTime();
+		Date accessTokenExpiresIn = new Date(now + 1000L * seconds);
+
+		return Jwts.builder()
+			.claim("body", Ut.json.toStr(claims))
+			.setExpiration(accessTokenExpiresIn)
+			.signWith(getSecretKey(), SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public boolean verify(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(getSecretKey())
+				.build()
+				.parseClaimsJws(token);
+		} catch (Exception e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public Map<String, Object> getClaims(String token) {
+		String body = Jwts.parserBuilder()
+			.setSigningKey(getSecretKey())
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get("body", String.class);
+
+		return Ut.json.toMap(body);
+	}
+}

--- a/src/main/java/com/wanted/moneyway/base/security/config/BaseConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/security/config/BaseConfig.java
@@ -1,10 +1,14 @@
 package com.wanted.moneyway.base.security.config;
 
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
 			//.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
 			.authorizeHttpRequests(
 				authorizeHttpRequests -> authorizeHttpRequests
-					.requestMatchers(HttpMethod.POST, "/api/*/member/signin").permitAll() // 회원가입 누구나 가능
+					.requestMatchers(HttpMethod.POST, "/api/*/member/signup").permitAll() // 회원가입 누구나 가능
 					.requestMatchers(HttpMethod.POST, "/api/*/member/login").permitAll() // 로그인은 누구나 가능
 					.anyRequest().authenticated() // 나머지는 인증된 사용자만 가능
 			)
@@ -34,7 +34,7 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
 		http
-			.securityMatcher("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html") // 아래 모든 설정은 /api/** 경로에만 적용
+			.securityMatcher("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html") // 아래 모든 설정은 swagger 관련 링크에만 적용
 			.cors().disable() // 타 도메인에서 API 호출 가능
 			.csrf().disable() // CSRF 토큰 끄기
 			.httpBasic().disable() // httpBaic 로그인 방식 끄기

--- a/src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -13,10 +14,11 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 			.securityMatcher("/api/**") // 아래 모든 설정은 /api/** 경로에만 적용
+			//.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
 			.authorizeHttpRequests(
 				authorizeHttpRequests -> authorizeHttpRequests
-					.requestMatchers("/api/*/member/signup").permitAll() // 회원가입은 누구나 가능
-					.requestMatchers("/api/*/member/login").permitAll() // 로그인은 누구나 가능
+					.requestMatchers(HttpMethod.POST, "/api/*/member/signin").permitAll() // 회원가입 누구나 가능
+					.requestMatchers(HttpMethod.POST, "/api/*/member/login").permitAll() // 로그인은 누구나 가능
 					.anyRequest().authenticated() // 나머지는 인증된 사용자만 가능
 			)
 			.cors().disable() // 타 도메인에서 API 호출 가능
@@ -26,7 +28,20 @@ public class SecurityConfig {
 			.sessionManagement(sessionManagement ->
 				sessionManagement.sessionCreationPolicy(STATELESS)
 			); // 세션끄기
+		return http.build();
+	}
 
+	@Bean
+	public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html") // 아래 모든 설정은 /api/** 경로에만 적용
+			.cors().disable() // 타 도메인에서 API 호출 가능
+			.csrf().disable() // CSRF 토큰 끄기
+			.httpBasic().disable() // httpBaic 로그인 방식 끄기
+			.formLogin().disable() // 폼 로그인 방식 끄기
+			.sessionManagement(sessionManagement ->
+				sessionManagement.sessionCreationPolicy(STATELESS)
+			); // 세션끄기
 		return http.build();
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/DTO/TokenDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/DTO/TokenDTO.java
@@ -1,0 +1,14 @@
+package com.wanted.moneyway.boundedContext.member.DTO;
+
+import lombok.Data;
+
+@Data
+public class TokenDTO {
+	private String accessToken;
+	private String refreshToken;
+
+	public TokenDTO (String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java
@@ -58,7 +58,7 @@ public class ApiV1MemberController {
 	public static class SignInRequest {
 		@NotBlank(message = "id를 입력해주세요")
 		@Schema(description = "사용자 계정", example = "user123")
-		private String account;
+		private String username;
 		@NotBlank(message = "pw를 입력해주세요")
 		@Schema(description = "사용자 비밀번호 (10자 이상, 숫자만으로 구성 불가, 3회 이상 연속되는 문자 사용 불가)", example = "password129")
 		private String password;
@@ -67,7 +67,7 @@ public class ApiV1MemberController {
 
 	@PostMapping("/login")
 	@Operation(summary = "JWT, RT 발급")
-	public RsData<TokenDTO> signIn(@Valid @RequestBody SignInRequest signInRequest, BindingResult bindingResult) {
+	public RsData<TokenDTO> login(@Valid @RequestBody SignInRequest signInRequest, BindingResult bindingResult) {
 		// 요청 객체에서 입력하지 않은 부분이 있다면 메세지를 담아서 RsData 객체 바로 리턴
 		if (bindingResult.hasErrors()) {
 			List<String> errorMessages = bindingResult.getAllErrors()
@@ -77,7 +77,7 @@ public class ApiV1MemberController {
 			return RsData.of("F-1", errorMessages.get(0));
 		}
 
-		RsData<TokenDTO> rsData = memberService.login(signInRequest.getAccount(), signInRequest.getPassword());
+		RsData<TokenDTO> rsData = memberService.login(signInRequest.getUsername(), signInRequest.getPassword());
 
 		return rsData;
 	}

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java
@@ -10,8 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.boundedContext.member.DTO.TokenDTO;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -21,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/api/v1/member")
+@Tag(name = "MemberController", description = "회원가입, 로그인처리 컨트롤러")
 public class ApiV1MemberController {
 	private final MemberService memberService;
 
@@ -45,6 +50,34 @@ public class ApiV1MemberController {
 		}
 		// 입력 이상 없다면 계정 가입
 		RsData rsData = memberService.join(signupRequest.getUsername(), signupRequest.getPassword());
+
+		return rsData;
+	}
+
+	@Data
+	public static class SignInRequest {
+		@NotBlank(message = "id를 입력해주세요")
+		@Schema(description = "사용자 계정", example = "user123")
+		private String account;
+		@NotBlank(message = "pw를 입력해주세요")
+		@Schema(description = "사용자 비밀번호 (10자 이상, 숫자만으로 구성 불가, 3회 이상 연속되는 문자 사용 불가)", example = "password129")
+		private String password;
+	}
+
+
+	@PostMapping("/login")
+	@Operation(summary = "JWT, RT 발급")
+	public RsData<TokenDTO> signIn(@Valid @RequestBody SignInRequest signInRequest, BindingResult bindingResult) {
+		// 요청 객체에서 입력하지 않은 부분이 있다면 메세지를 담아서 RsData 객체 바로 리턴
+		if (bindingResult.hasErrors()) {
+			List<String> errorMessages = bindingResult.getAllErrors()
+				.stream()
+				.map(error -> error.getDefaultMessage())
+				.collect(Collectors.toList());
+			return RsData.of("F-1", errorMessages.get(0));
+		}
+
+		RsData<TokenDTO> rsData = memberService.login(signInRequest.getAccount(), signInRequest.getPassword());
 
 		return rsData;
 	}

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.wanted.moneyway.boundedContext.member.entity;
 import static jakarta.persistence.GenerationType.*;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +16,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,9 +53,9 @@ public class Member {
 	}
 
 	public Map<String, Object> toClaims() {
-			return Map.of(
-				"id", getId(),
-				"userName", getUserName()
-			);
+		Map<String, Object> result = new HashMap<>();
+		result.put("id", getId());
+		result.put("userName", getUserName());
+		return result;
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.GenerationType.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -49,5 +50,12 @@ public class Member {
 
 	public void updateRefreshToken(String refreshToken) {
 		this.refreshToken = refreshToken;
+	}
+
+	public Map<String, Object> toClaims() {
+			return Map.of(
+				"id", getId(),
+				"userName", getUserName()
+			);
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
@@ -33,7 +33,7 @@ public class Member {
 	private String userName;
 	@JsonIgnore
 	private String password;
-	private String accessToken;
+	private String refreshToken;
 
 	public List<? extends GrantedAuthority> getGrantedAuthorities() {
 		List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
@@ -45,5 +45,9 @@ public class Member {
 		}
 
 		return grantedAuthorities;
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
@@ -1,12 +1,15 @@
 package com.wanted.moneyway.boundedContext.member.service;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.moneyway.base.jwt.JwtProvider;
 import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.boundedContext.member.DTO.TokenDTO;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.repository.MemberRepository;
 
@@ -18,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
+
+	private final JwtProvider jwtProvider;
 	@Transactional
 	public RsData join(String account, String password) {
 		Optional<Member> opMember = memberRepository.findByUserName(account);
@@ -33,5 +38,49 @@ public class MemberService {
 		memberRepository.save(member);
 
 		return RsData.of("S-1", "회원가입 완료 로그인 후 이용해주세요!");
+	}
+
+	@Transactional
+	public RsData<TokenDTO> login(String name, String password) {
+		Optional<Member> _member = memberRepository.findByUserName(name);
+
+		if(_member == null)
+			return	RsData.of("F-1", "존재하지 않는 회원입니다.");
+
+		Member member = _member.get();
+
+		RsData rsData = canGenToken(member, password);
+
+		if (rsData.isFail())
+			return rsData;
+
+		String accessToken = genAccessToken(member);
+		String refreshToken = genRefreshToken(member);
+
+		// 리프레시 토큰 갱신
+		member.updateRefreshToken(refreshToken);
+
+		return RsData.of("S-1", "토큰 발급 성공", new TokenDTO(accessToken, refreshToken));
+
+	}
+
+	private String genRefreshToken(Member member) {
+		Map<String, Object> memberInfo = member.toClaims();
+		memberInfo.put("Type", "Refresh");
+		// 3일짜리 RT 발급
+		return jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 3);
+	}
+
+	private RsData canGenToken(Member member, String password) {
+		if (!passwordEncoder.matches(password, member.getPassword())) {
+			return RsData.of("F-1", "비밀번호가 일치하지 않습니다.");
+		}
+
+		return RsData.of("S-1", "AT, RT를 생성할 수 있습니다.");
+	}
+
+	public String genAccessToken(Member member) {
+		// 1일 짜리 JWT 발급
+		return jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
 	}
 }

--- a/src/main/java/com/wanted/moneyway/standard/util/Ut.java
+++ b/src/main/java/com/wanted/moneyway/standard/util/Ut.java
@@ -1,0 +1,31 @@
+package com.wanted.moneyway.standard.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Ut {
+	public static class json {
+		// map을 Json 형태 변환 매서드
+		public static Object toStr(Map<String, Object> map) {
+			try {
+				// Jackson 라이브러리 ObjectMapper 클래스 사용하여 map 객체를 Json형태
+				// Java <-> Json 처리 작업 간단하게 해주는 클래스
+				return new ObjectMapper().writeValueAsString(map);
+			} catch (JsonProcessingException e) {
+				return null;
+			}
+		}
+
+		// json 형태 데이터를 map 형태로 변환
+		public static Map<String, Object> toMap(String jsonStr) {
+			try {
+				return new ObjectMapper().readValue(jsonStr, LinkedHashMap.class);
+			} catch (JsonProcessingException e) {
+				return null;
+			}
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   profiles:
     active: dev
     include: secret
+  h2:
+    console:
+      enabled: false
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/java/com/wanted/moneyway/base/jwt/JwtTests.java
+++ b/src/test/java/com/wanted/moneyway/base/jwt/JwtTests.java
@@ -1,0 +1,112 @@
+package com.wanted.moneyway.base.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.jsonwebtoken.security.Keys;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class JwtTests {
+	@Value("${custom.jwt.secretKey}")
+	private String secretKeyPlain;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Test
+	@DisplayName("secretKey 키가 존재해야한다.")
+	void t1() {
+		assertThat(secretKeyPlain).isNotNull();
+	}
+
+	@Test
+	@DisplayName("sercretKey 원문으로 hmac 암호화 알고리즘에 맞는 SecretKey 객체를 만들 수 있다.")
+	void t2() {
+		// 키를 Base64 인코딩 한다.
+		String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKeyPlain.getBytes());
+		// Base64 인코딩된 키를 이용하여 SecretKey 객체를 만든다.
+		SecretKey secretKey = Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
+
+		assertThat(secretKey).isNotNull();
+	}
+
+	@Test
+	@DisplayName("JwtProvider 객체로 SecretKey 객체를 생성할 수 있다.")
+	void t3() {
+		SecretKey secretKey = jwtProvider.getSecretKey();
+
+		assertThat(secretKey).isNotNull();
+	}
+
+	@Test
+	@DisplayName("SecretKey 객체는 단 한번만 생성되어야 한다.")
+	void t4() {
+		SecretKey secretKey1 = jwtProvider.getSecretKey();
+		SecretKey secretKey2 = jwtProvider.getSecretKey();
+
+		assertThat(secretKey1 == secretKey2).isTrue();
+	}
+
+	@Test
+	@DisplayName("accessToken 을 얻는다.")
+	void t5() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", 1L);
+		claims.put("username", "admin");
+
+		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
+		String accessToken = jwtProvider.genAccessToken(claims, 60 * 60 * 5);
+
+		System.out.println("accessToken : " + accessToken);
+
+		assertThat(accessToken).isNotNull();
+	}
+
+	@Test
+	@DisplayName("accessToken 을 통해서 claims 를 얻을 수 있다.")
+	void t6() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", 1L);
+		claims.put("username", "admin");
+
+		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
+		String accessToken = jwtProvider.genAccessToken(claims, 60 * 60 * 5);
+
+		System.out.println("accessToken : " + accessToken);
+
+		assertThat(jwtProvider.verify(accessToken)).isTrue();
+
+		Map<String, Object> claimsFromToken = jwtProvider.getClaims(accessToken);
+		System.out.println("claimsFromToken : " + claimsFromToken);
+	}
+
+	@Test
+	@DisplayName("만료된 토큰을 유효하지 않다.")
+	void t7() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", 1L);
+		claims.put("username", "admin");
+
+		// 만료 기간을 현재 시간보다 -1초로 설정 -> 만료 토큰 생성
+		String accessToken = jwtProvider.genAccessToken(claims, -1);
+
+		System.out.println("accessToken : " + accessToken);
+
+		assertThat(jwtProvider.verify(accessToken)).isFalse();
+	}
+}

--- a/src/test/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberControllerTest.java
@@ -1,4 +1,4 @@
-package com.wanted.moneyway.member.controller;
+package com.wanted.moneyway.boundedContext.member.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;

--- a/src/test/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberControllerTest.java
@@ -48,4 +48,54 @@ public class ApiV1MemberControllerTest {
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.msg").value("회원가입 완료 로그인 후 이용해주세요!"));
 	}
+
+	@Test
+	@DisplayName("회원가입 시 비밀번호 제약조건을 지키지 않으면 가입이 되지 않는다.")
+	void t2() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/api/v1/member/signup")
+					.content("""
+						{
+						    "username": "puar12",
+						    "password": "1234"
+						}
+						""".stripIndent())
+					// JSON 형태로 보내겠다
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("비밀번호는 10자 이상 입력해야 하며, 숫자로만 이루어 질 수 없으며 3회 이상 연속되는 문자를 사용할 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("POST /api/v1/member/login을 통해 로그인 시 JWT 발행")
+	void t3() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/api/v1/member/login")
+					.content("""
+						{
+						    "username": "user1",
+						    "password": "1234"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("토큰 발급 성공"))
+			.andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+			.andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️관련 이슈[#]
close #3 
### 📑 개요
- 로그인 시 토큰 발행, 시큐리티 필터체인 도입
- 데이터 초기화, 관련 테스트케이스 추가
- Swagger 문서에도 JWT(AT + RT) 방식 적용하도록 수정

###  🧷 변경사항
- **src/main/java/com/wanted/moneyway/base/config/SwaggerConfig.java**
  - Swagger에서 JWT 중 AT와 RT 용 스키마 정의합니다.
    - 아직 로직에는 사용 전입니다.
- **src/main/java/com/wanted/moneyway/base/initData/NotProd.java**
  - 테스트용 회원 3명을 추가합니다.
- **src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java**
  - JWT를 발행하고 검증하는 로직을 담고있습니다.

- **src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java**
  - SecurityFilterChain 관련 설정으로 회원가입, 로그인 페이지에 POST요청을 명시하여 좀 더 정교하게 허용합니다.
    - swaggerSecurityFilterChain의 경우 swagger 문서를 보는 것으로, 다른 곳에서 호출할 수 있도록 cors 설정을 끄고, JWT 인증 방식을 저장합니다.
    - 추후 admin만 접속 가능하게 한다는 등의 기능 확장성을 위해 로그인 방식과 관련된 설정도 남겨두었습니다.

- **src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java**
  - login : 사용자 ID/PW를 입력받아 토큰을 발급합니다

- **src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java**
  - login : 사용자 ID/PW를 검증하여 토큰을 발행합니다. 리프래시 토큰의 경우 DB갱신도 이루어집니다.
  - genRefreshToken : 리프래시 토큰 3일간 유효한 토큰을 발행합니다.
   - genAccessToken : 1일짜리 JWT를 발급합니다. 실제로는 5분 등 짧은 시간동안만 유효하도록 하지만, 기능 개발 중 테스트를 위해 1일로 잡았습니다(Swagger 등에서 테스트 해보기 위함)

- **src/main/resources/application.yml**
  - H2 DB를 사용하면 H2 웹 서블릿이 추가로 발생하는데, 스프링에서 스프링 서블릿 매핑인지 H2 서블릿 매핑인지 명확하지 않아 에러가 발생합니다.
   - 따라서 H2 DB의 웹 콘솔을 비활성화 하여 문제를 해결하였습니다.

## 📷 스크린샷

## 👀 기타
