### PR TITLE
[Feat] JWT 인증 필터 구현

### DIFF
--- a/src/main/java/com/wanted/moneyway/base/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/config/SwaggerConfig.java
@@ -25,10 +25,10 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 	scheme = "bearer"
 )
 @SecurityScheme(
-	name = "refreshToken",
+	name = "RefreshToken",
 	type = SecuritySchemeType.APIKEY,
 	in = SecuritySchemeIn.HEADER,
-	paramName = "X-Refresh-Token"
+	paramName = "RefreshToken"
 )
 public class SwaggerConfig {
 }

--- a/src/main/java/com/wanted/moneyway/base/exceptionHandler/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/moneyway/base/exceptionHandler/ApiGlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.wanted.moneyway.base.exceptionHandler;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.stream.Collectors;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.wanted.moneyway.base.rsData.RsData;
+
+@RestControllerAdvice(annotations = {RestController.class}) // 모든 @RestController 에서 발생한 예외에 대한 제어권을 가로챈다.
+public class ApiGlobalExceptionHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseStatus(NOT_FOUND)
+	public RsData<String> errorHandler(MethodArgumentNotValidException exception) {
+		String msg = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.collect(Collectors.joining("/"));
+
+		String data = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getCode)
+			.collect(Collectors.joining("/"));
+
+		return RsData.of("F-MethodArgumentNotValidException", msg, data);
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	public RsData<String> errorHandler(RuntimeException exception) {
+		String msg = exception.getClass().toString();
+
+		String data = exception.getMessage();
+
+		return RsData.of("F-RuntimeException", msg, data);
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	@ResponseStatus(UNAUTHORIZED) // 예외에 따른 HTTP 상태 코드 설정
+	public RsData<String> handleAuthenticationException(AuthenticationException exception) {
+		String msg = exception.getMessage(); // 예외 메시지 추출
+
+		// RsData.of 메서드 호출
+		return RsData.of("F-AuthenticationException", msg);
+	}
+}

--- a/src/main/java/com/wanted/moneyway/base/exceptionHandler/AuthenticationException.java
+++ b/src/main/java/com/wanted/moneyway/base/exceptionHandler/AuthenticationException.java
@@ -1,0 +1,7 @@
+package com.wanted.moneyway.base.exceptionHandler;
+
+public class AuthenticationException extends RuntimeException {
+	public AuthenticationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java
+++ b/src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java
@@ -34,17 +34,6 @@ public class JwtProvider {
 		return cachedSecretKey;
 	}
 
-	public String genAccessToken(Map<String, Object> claims, int seconds) {
-		long now = new Date().getTime();
-		Date accessTokenExpiresIn = new Date(now + 1000L * seconds);
-
-		return Jwts.builder()
-			.claim("body", Ut.json.toStr(claims))
-			.setExpiration(accessTokenExpiresIn)
-			.signWith(getSecretKey(), SignatureAlgorithm.HS512)
-			.compact();
-	}
-
 	public String genToken(Map<String, Object> claims, int seconds) {
 		long now = new Date().getTime();
 		Date accessTokenExpiresIn = new Date(now + 1000L * seconds);

--- a/src/main/java/com/wanted/moneyway/base/security/config/BaseConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/security/config/BaseConfig.java
@@ -1,14 +1,10 @@
 package com.wanted.moneyway.base.security.config;
 
-import static org.springframework.security.config.http.SessionCreationPolicy.*;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java
@@ -7,9 +7,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.wanted.moneyway.base.security.filter.JwtAuthorizationFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+	private final JwtAuthorizationFilter jwtAuthorizationFilter;
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
@@ -27,7 +34,11 @@ public class SecurityConfig {
 			.formLogin().disable() // 폼 로그인 방식 끄기
 			.sessionManagement(sessionManagement ->
 				sessionManagement.sessionCreationPolicy(STATELESS)
-			); // 세션끄기
+			) // 세션끄기
+			.addFilterBefore(
+				jwtAuthorizationFilter, // 엑세스 토큰으로 부터 로그인 처리
+				UsernamePasswordAuthenticationFilter.class
+			);
 		return http.build();
 	}
 

--- a/src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java
@@ -2,6 +2,7 @@ package com.wanted.moneyway.base.security.filter;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.security.sasl.AuthenticationException;
 
@@ -15,7 +16,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.wanted.moneyway.base.jwt.JwtProvider;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
-import com.wanted.moneyway.standard.util.Ut;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -33,58 +33,80 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
+		String requestURI = request.getRequestURI();
+
+		// 회원가입 및 로그인 요청에 대해서는 필터를 건너뛰기
+		if (Pattern.matches("/api/.*/member/signup", requestURI) || Pattern.matches("/api/.*/member/login", requestURI)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// swagger 문서 접속에 대해서도 필터 건너뛰기
+		if (Pattern.matches("/v3/api-docs/.*", requestURI) || Pattern.matches("/swagger-ui/.*", requestURI) || requestURI.startsWith("/swagger-ui.html")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		String bearerToken = request.getHeader("Authorization");
 		String refreshToken = request.getHeader("RefreshToken");
 
-		// JWT의 Accss Token이 유효한 경우 사용자 정보 추출해서 바로 로그인 처리
+		if (bearerToken == null && refreshToken == null) {
+			throw new AuthenticationException("AT와 RT 둘 중 하나는 헤더에 포함시켜주세요");
+		}
+		// AT가 유효하다면 인증처리
 		if (bearerToken != null && isTokenValid(bearerToken.substring("Bearer ".length()))) {
 			forceAuthentication(getMemberFromToken(bearerToken.substring("Bearer ".length())));
+			filterChain.doFilter(request, response);
+			return;  // 다음 필터로 전달되어도 이 메서드는 종료되지 않고 계속 실행하므로 명시적 종료
 		}
-
-		// JWT AT가 유효하지 않은 경우 RT를 검사해서 RT가 아직 유효한지 확인
-		else if (refreshToken != null && isTokenValid(refreshToken)) {
+		// AT유효하지 않은데, RT가 없다면
+		if (refreshToken == null) {
+			throw new AuthenticationException("만료된 AT입니다. RT를 포함시켜주세요.");
+		}
+		// RT 유효한지 검사
+		if (isTokenValid(refreshToken)) {
 			Member member = getMemberFromToken(refreshToken);
-			// DB에 저장된 RT와 비교하여 같을 경우 강제 로그인 처리
-			if(member.getRefreshToken().equals(refreshToken)) {
-				Map<String, Object> newMemberClaims = member.toClaims();;
-				// 1일짜리 JWT AT 설정
+			// 사용자 DB에 저장된 RT와 같다면
+			if (member.getRefreshToken().equals(refreshToken)) {
+				Map<String, Object> newMemberClaims = member.toClaims();
 				String newAccessToken = jwtProvider.genToken(newMemberClaims, 60 * 60 * 24 * 1);
-				// 새로운 AT를 response 헤더에 추가하여 반환
 				response.addHeader("Authorization", "Bearer " + newAccessToken);
-				// 로그인 처리
 				forceAuthentication(member);
 			}
+			// 다르다면 변경된 RT이므로 재 로그인
+			else {
+				throw new AuthenticationException("유효하지 않은 RT입니다. 재 로그인 해주세요.");
+			}
+		} else {
+			throw new AuthenticationException("토큰이 만료되었습니다. 재 로그인 해주세요.");
 		}
+
 		filterChain.doFilter(request, response);
 	}
 
-	private Member getMemberFromToken(String token) {
+	private Member getMemberFromToken(String token) throws AuthenticationException {
 		Map<String, Object> claims = jwtProvider.getClaims(token);
-		long id = (int)claims.get("id");
-		return memberService.get(id);
+		long id = (long)claims.get("id");
+		Member member = memberService.get(id);
+		if(member == null)
+			throw new AuthenticationException("존재하지 않는 사용자입니다.");
+		return member;
 	}
 
 	private boolean isTokenValid(String token) {
 		return jwtProvider.verify(token);
 	}
 
-	// 강제로 로그인 처리하는 메소드
 	private void forceAuthentication(Member member) {
 		User user = new User(member.getUserName(), member.getPassword(), member.getGrantedAuthorities());
-
-		// 스프링 시큐리티 객체에 저장할 authentication 객체를 생성
 		UsernamePasswordAuthenticationToken authentication =
 			UsernamePasswordAuthenticationToken.authenticated(
 				user,
 				null,
 				member.getGrantedAuthorities()
 			);
-
-		// 스프링 시큐리티 내에 우리가 만든 authentication 객체를 저장할 context 생성
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
-		// context에 authentication 객체를 저장
 		context.setAuthentication(authentication);
-		// 스프링 시큐리티에 context를 등록
 		SecurityContextHolder.setContext(context);
 	}
 }

--- a/src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,90 @@
+package com.wanted.moneyway.base.security.filter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.security.sasl.AuthenticationException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.wanted.moneyway.base.jwt.JwtProvider;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.service.MemberService;
+import com.wanted.moneyway.standard.util.Ut;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+	private final JwtProvider jwtProvider;
+	private final MemberService memberService;
+
+	@Override
+	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String bearerToken = request.getHeader("Authorization");
+		String refreshToken = request.getHeader("RefreshToken");
+
+		// JWT의 Accss Token이 유효한 경우 사용자 정보 추출해서 바로 로그인 처리
+		if (bearerToken != null && isTokenValid(bearerToken.substring("Bearer ".length()))) {
+			forceAuthentication(getMemberFromToken(bearerToken.substring("Bearer ".length())));
+		}
+
+		// JWT AT가 유효하지 않은 경우 RT를 검사해서 RT가 아직 유효한지 확인
+		else if (refreshToken != null && isTokenValid(refreshToken)) {
+			Member member = getMemberFromToken(refreshToken);
+			// DB에 저장된 RT와 비교하여 같을 경우 강제 로그인 처리
+			if(member.getRefreshToken().equals(refreshToken)) {
+				Map<String, Object> newMemberClaims = member.toClaims();;
+				// 1일짜리 JWT AT 설정
+				String newAccessToken = jwtProvider.genToken(newMemberClaims, 60 * 60 * 24 * 1);
+				// 새로운 AT를 response 헤더에 추가하여 반환
+				response.addHeader("Authorization", "Bearer " + newAccessToken);
+				// 로그인 처리
+				forceAuthentication(member);
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private Member getMemberFromToken(String token) {
+		Map<String, Object> claims = jwtProvider.getClaims(token);
+		long id = (int)claims.get("id");
+		return memberService.get(id);
+	}
+
+	private boolean isTokenValid(String token) {
+		return jwtProvider.verify(token);
+	}
+
+	// 강제로 로그인 처리하는 메소드
+	private void forceAuthentication(Member member) {
+		User user = new User(member.getUserName(), member.getPassword(), member.getGrantedAuthorities());
+
+		// 스프링 시큐리티 객체에 저장할 authentication 객체를 생성
+		UsernamePasswordAuthenticationToken authentication =
+			UsernamePasswordAuthenticationToken.authenticated(
+				user,
+				null,
+				member.getGrantedAuthorities()
+			);
+
+		// 스프링 시큐리티 내에 우리가 만든 authentication 객체를 저장할 context 생성
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		// context에 authentication 객체를 저장
+		context.setAuthentication(authentication);
+		// 스프링 시큐리티에 context를 등록
+		SecurityContextHolder.setContext(context);
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
@@ -83,4 +83,8 @@ public class MemberService {
 		// 1일 짜리 JWT 발급
 		return jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
 	}
+
+	public Member get(long memberId) {
+		return memberRepository.findById(memberId).get();
+	}
 }

--- a/src/test/java/com/wanted/moneyway/MoneywayApplicationTests.java
+++ b/src/test/java/com/wanted/moneyway/MoneywayApplicationTests.java
@@ -2,8 +2,10 @@ package com.wanted.moneyway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MoneywayApplicationTests {
 
 	@Test

--- a/src/test/java/com/wanted/moneyway/base/jwt/JwtTests.java
+++ b/src/test/java/com/wanted/moneyway/base/jwt/JwtTests.java
@@ -70,7 +70,7 @@ class JwtTests {
 		claims.put("username", "admin");
 
 		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
-		String accessToken = jwtProvider.genAccessToken(claims, 60 * 60 * 5);
+		String accessToken = jwtProvider.genToken(claims, 60 * 60 * 5);
 
 		System.out.println("accessToken : " + accessToken);
 
@@ -85,7 +85,7 @@ class JwtTests {
 		claims.put("username", "admin");
 
 		// 지금으로부터 5시간의 유효기간을 가지는 토큰을 생성
-		String accessToken = jwtProvider.genAccessToken(claims, 60 * 60 * 5);
+		String accessToken = jwtProvider.genToken(claims, 60 * 60 * 5);
 
 		System.out.println("accessToken : " + accessToken);
 
@@ -103,7 +103,7 @@ class JwtTests {
 		claims.put("username", "admin");
 
 		// 만료 기간을 현재 시간보다 -1초로 설정 -> 만료 토큰 생성
-		String accessToken = jwtProvider.genAccessToken(claims, -1);
+		String accessToken = jwtProvider.genToken(claims, -1);
 
 		System.out.println("accessToken : " + accessToken);
 


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #5 
### 📑 개요
- JWT 인증 필터를 도입하여 인증이 필요한 기능에 JWT인증이 되도록 구현하였습니다.
- 각 상황에 맞는 예외처리를 함으로써 클라이언트에게 왜 예외처리 되었는지 명확하게 알려줍니다.
- 발생할 다른 예외들도 RsData 형식으로 통일하였습니다.
###  🧷 변경사항
- **src/main/java/com/wanted/moneyway/base/exceptionHandler/ApiGlobalExceptionHandler.java**
  - 예외 처리 메세지를 RsData 양식으로 통일하였습니다.

- **src/main/java/com/wanted/moneyway/base/security/config/SecurityConfig.java**
  - UsernamePassword 인증 필터 전에 JWT 필터를 적용될 수 있도록 설정을 변경하였습니다.

- **src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java**
  - 로그인, 회원가입, swagger 문서 접속에는 필터가 적용되지 않도록 명시하였습니다.
  - Case 1. AT가 유효한 경우 : 인증 처리 및 함수 종료
  - Case 2. AT 만료 -> RT 유효 -> AT 재발급 -> 응답 헤더에 추가하여 응답 및 로그인 처리
    - 그 외 각각 상황에 맞는 예외 처리를 하였습니다.
  - forceAuthentication : 강제 로그인 처리를 하는 메서드로 SecurityContext에 User 객체를 만들고 추가합니다.


## 📷 스크린샷

## 👀 기타
- 로그인한 사용자 추출 : @AuthenticationPrincipal User user 로 추출 가능