### PR TITLE
[Feat] 예산 설계 및 추천 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ dependencies {
 
     // 스프링독 추가(스웨거 사용 위함)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+    //querydsl
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    implementation "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
 }
 
 tasks.named('test') {

--- a/src/main/generated/com/wanted/moneyway/boundedContext/category/entity/QCategory.java
+++ b/src/main/generated/com/wanted/moneyway/boundedContext/category/entity/QCategory.java
@@ -1,0 +1,41 @@
+package com.wanted.moneyway.boundedContext.category.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCategory is a Querydsl query type for Category
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCategory extends EntityPathBase<Category> {
+
+    private static final long serialVersionUID = 1206136616L;
+
+    public static final QCategory category = new QCategory("category");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath nameE = createString("nameE");
+
+    public final StringPath nameH = createString("nameH");
+
+    public QCategory(String variable) {
+        super(Category.class, forVariable(variable));
+    }
+
+    public QCategory(Path<? extends Category> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCategory(PathMetadata metadata) {
+        super(Category.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/wanted/moneyway/boundedContext/expenditure/entity/QExpenditure.java
+++ b/src/main/generated/com/wanted/moneyway/boundedContext/expenditure/entity/QExpenditure.java
@@ -1,0 +1,62 @@
+package com.wanted.moneyway.boundedContext.expenditure.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QExpenditure is a Querydsl query type for Expenditure
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QExpenditure extends EntityPathBase<Expenditure> {
+
+    private static final long serialVersionUID = 350800562L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QExpenditure expenditure = new QExpenditure("expenditure");
+
+    public final com.wanted.moneyway.boundedContext.category.entity.QCategory category;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isTotal = createBoolean("isTotal");
+
+    public final com.wanted.moneyway.boundedContext.member.entity.QMember member;
+
+    public final StringPath memo = createString("memo");
+
+    public final DateTimePath<java.time.LocalDateTime> spendDate = createDateTime("spendDate", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> spendingPrice = createNumber("spendingPrice", Integer.class);
+
+    public QExpenditure(String variable) {
+        this(Expenditure.class, forVariable(variable), INITS);
+    }
+
+    public QExpenditure(Path<? extends Expenditure> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QExpenditure(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QExpenditure(PathMetadata metadata, PathInits inits) {
+        this(Expenditure.class, metadata, inits);
+    }
+
+    public QExpenditure(Class<? extends Expenditure> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.category = inits.isInitialized("category") ? new com.wanted.moneyway.boundedContext.category.entity.QCategory(forProperty("category")) : null;
+        this.member = inits.isInitialized("member") ? new com.wanted.moneyway.boundedContext.member.entity.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/wanted/moneyway/boundedContext/member/entity/QMember.java
+++ b/src/main/generated/com/wanted/moneyway/boundedContext/member/entity/QMember.java
@@ -1,0 +1,43 @@
+package com.wanted.moneyway.boundedContext.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -1158593632L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath password = createString("password");
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    public final StringPath userName = createString("userName");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/wanted/moneyway/boundedContext/plan/entity/QPlan.java
+++ b/src/main/generated/com/wanted/moneyway/boundedContext/plan/entity/QPlan.java
@@ -1,0 +1,56 @@
+package com.wanted.moneyway.boundedContext.plan.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPlan is a Querydsl query type for Plan
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPlan extends EntityPathBase<Plan> {
+
+    private static final long serialVersionUID = -1009301634L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPlan plan = new QPlan("plan");
+
+    public final NumberPath<Integer> budget = createNumber("budget", Integer.class);
+
+    public final com.wanted.moneyway.boundedContext.category.entity.QCategory category;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.wanted.moneyway.boundedContext.member.entity.QMember member;
+
+    public QPlan(String variable) {
+        this(Plan.class, forVariable(variable), INITS);
+    }
+
+    public QPlan(Path<? extends Plan> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPlan(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPlan(PathMetadata metadata, PathInits inits) {
+        this(Plan.class, metadata, inits);
+    }
+
+    public QPlan(Class<? extends Plan> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.category = inits.isInitialized("category") ? new com.wanted.moneyway.boundedContext.category.entity.QCategory(forProperty("category")) : null;
+        this.member = inits.isInitialized("member") ? new com.wanted.moneyway.boundedContext.member.entity.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/wanted/moneyway/boundedContext/plan/entity/QPlan.java
+++ b/src/main/generated/com/wanted/moneyway/boundedContext/plan/entity/QPlan.java
@@ -26,6 +26,8 @@ public class QPlan extends EntityPathBase<Plan> {
 
     public final com.wanted.moneyway.boundedContext.category.entity.QCategory category;
 
+    public final NumberPath<Double> categoryRatio = createNumber("categoryRatio", Double.class);
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final com.wanted.moneyway.boundedContext.member.entity.QMember member;

--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -13,13 +13,15 @@ import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.repository.CategoryRepository;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.repository.MemberRepository;
+import com.wanted.moneyway.boundedContext.plan.dto.PlanDTO;
+import com.wanted.moneyway.boundedContext.plan.service.PlanService;
 
 @Configuration
 @Profile({"dev", "test"})
 public class NotProd {
 	@Bean
 	CommandLineRunner initData(MemberRepository memberRepository, PasswordEncoder passwordEncoder,
-		CategoryRepository categoryRepository) {
+		CategoryRepository categoryRepository, PlanService planService) {
 		return args -> {
 			String password = passwordEncoder.encode("1234");
 			List<Member> memberList = new ArrayList<>();
@@ -94,6 +96,16 @@ public class NotProd {
 			categoryList.add(category8);
 
 			categoryRepository.saveAll(categoryList);
+
+			int cafe = 100_000, dwelling = 100_000, food = 100_000, communication = 100_000,
+				education = 100_000, shopping = 100_000, transfer = 100_000, others = 100_000;
+			PlanDTO planDTO1 = new PlanDTO(food, cafe, education, dwelling, communication, shopping, transfer, others);
+
+			planService.register(planDTO1, user1.getUserName());
+			planService.register(planDTO1, user2.getUserName());
+			planService.register(planDTO1, user3.getUserName());
+
+
 		};
 	}
 }

--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -18,7 +18,8 @@ import com.wanted.moneyway.boundedContext.member.repository.MemberRepository;
 @Profile({"dev", "test"})
 public class NotProd {
 	@Bean
-	CommandLineRunner initData(MemberRepository memberRepository, PasswordEncoder passwordEncoder, CategoryRepository categoryRepository) {
+	CommandLineRunner initData(MemberRepository memberRepository, PasswordEncoder passwordEncoder,
+		CategoryRepository categoryRepository) {
 		return args -> {
 			String password = passwordEncoder.encode("1234");
 			List<Member> memberList = new ArrayList<>();
@@ -43,49 +44,44 @@ public class NotProd {
 			memberRepository.saveAll(memberList);
 
 			List<Category> categoryList = new ArrayList<>();
-
 			Category category1 = Category.builder()
-				.name("식비")
+				.nameH("식비")
+				.nameE("food")
 				.build();
 
 			Category category2 = Category.builder()
-				.name("카페/간식")
+				.nameH("카페/간식")
+				.nameE("cafe")
 				.build();
 
 			Category category3 = Category.builder()
-				.name("생활")
+				.nameH("교육")
+				.nameE("education")
 				.build();
 
 			Category category4 = Category.builder()
-				.name("주거")
+				.nameH("주거")
+				.nameE("dwelling")
 				.build();
 
 			Category category5 = Category.builder()
-				.name("통신")
+				.nameH("통신")
+				.nameE("communication")
 				.build();
 
 			Category category6 = Category.builder()
-				.name("패션쇼핑")
+				.nameH("쇼핑")
+				.nameE("shopping")
 				.build();
 
 			Category category7 = Category.builder()
-				.name("뷰티/미용")
+				.nameH("교통")
+				.nameE("transfer")
 				.build();
 
 			Category category8 = Category.builder()
-				.name("문화/여가")
-				.build();
-
-			Category category9 = Category.builder()
-				.name("여행/숙박")
-				.build();
-
-			Category category10 = Category.builder()
-				.name("교통")
-				.build();
-
-			Category category11 = Category.builder()
-				.name("교육")
+				.nameH("기타")
+				.nameE("others")
 				.build();
 
 			categoryList.add(category1);
@@ -96,9 +92,6 @@ public class NotProd {
 			categoryList.add(category6);
 			categoryList.add(category7);
 			categoryList.add(category8);
-			categoryList.add(category9);
-			categoryList.add(category10);
-			categoryList.add(category11);
 
 			categoryRepository.saveAll(categoryList);
 		};

--- a/src/main/java/com/wanted/moneyway/base/security/config/BaseConfig.java
+++ b/src/main/java/com/wanted/moneyway/base/security/config/BaseConfig.java
@@ -6,6 +6,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -16,6 +19,11 @@ public class BaseConfig {
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
 	}
 
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/category/entity/Category.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/category/entity/Category.java
@@ -22,5 +22,8 @@ public class Category {
 	private Long id;
 
 	@Column(unique = true)
-	private String name;
+	private String nameE;
+
+	@Column(unique = true)
+	private String nameH;
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
@@ -35,7 +35,8 @@ public class ApiV1PlanController {
 
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("")
-	public RsData<List<Plan>> create(PlanDTO planDTO, @AuthenticationPrincipal User user) {
+	public RsData<List<Plan>> create(@RequestBody PlanDTO planDTO, @AuthenticationPrincipal User user) {
+		System.out.println(planDTO.toString());
 		if(planDTO.checkAllZero())
 			return RsData.of("F-1", "예산 항목 하나라도 입력 해야 등록 가능합니다.");
 

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
@@ -10,6 +10,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.wanted.moneyway.base.rsData.RsData;
@@ -36,12 +37,22 @@ public class ApiV1PlanController {
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("")
 	public RsData<List<Plan>> create(@RequestBody PlanDTO planDTO, @AuthenticationPrincipal User user) {
-		System.out.println(planDTO.toString());
 		if(planDTO.checkAllZero())
 			return RsData.of("F-1", "예산 항목 하나라도 입력 해야 등록 가능합니다.");
 
 		RsData<List<Plan>> rsData = planService.register(planDTO, user.getUsername());
 
 		return rsData;
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@PostMapping("/recommend")
+	public RsData<PlanDTO> recommend(@RequestParam Integer totalPrice, @AuthenticationPrincipal User user) {
+		if(totalPrice == null || totalPrice.equals(0)) {
+			return RsData.of("F-1", "총 금액을 입력해주셔야 추천 가능합니다.");
+		}
+		PlanDTO dto = planService.recommend(totalPrice);
+
+		return RsData.of("S-1", "항목별 추천 금액", dto);
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
@@ -1,0 +1,46 @@
+package com.wanted.moneyway.boundedContext.plan.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.boundedContext.member.controller.ApiV1MemberController;
+import com.wanted.moneyway.boundedContext.plan.dto.PlanDTO;
+import com.wanted.moneyway.boundedContext.plan.entity.Plan;
+import com.wanted.moneyway.boundedContext.plan.service.PlanService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/api/v1/plan")
+@Tag(name = "PlanController", description = "예산 계획 수립, 추천 컨트롤러")
+public class ApiV1PlanController {
+
+	private final PlanService planService;
+
+	@PreAuthorize("isAuthenticated()")
+	@PostMapping("")
+	public RsData<List<Plan>> create(PlanDTO planDTO, @AuthenticationPrincipal User user) {
+		if(planDTO.checkAllZero())
+			return RsData.of("F-1", "예산 항목 하나라도 입력 해야 등록 가능합니다.");
+
+		RsData<List<Plan>> rsData = planService.register(planDTO, user.getUsername());
+
+		return rsData;
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
@@ -19,6 +19,8 @@ import com.wanted.moneyway.boundedContext.plan.service.PlanService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Data;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -44,13 +46,18 @@ public class ApiV1PlanController {
 		return rsData;
 	}
 
+	@Data
+	public static class TotalPriceDTO {
+		private Integer totalPrice;
+	}
+
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/recommend")
-	public RsData<PlanDTO> recommend(@RequestParam Integer totalPrice) {
-		if (totalPrice == null || totalPrice.equals(0)) {
+	public RsData<PlanDTO> recommend(@RequestBody TotalPriceDTO totalPriceDTO) {
+		if (totalPriceDTO.getTotalPrice() == null || totalPriceDTO.getTotalPrice().equals(0)) {
 			return RsData.of("F-1", "총 금액을 입력해주셔야 추천 가능합니다.");
 		}
-		PlanDTO dto = planService.recommend(totalPrice);
+		PlanDTO dto = planService.recommend(totalPriceDTO.getTotalPrice());
 
 		return RsData.of("S-1", "항목별 추천 금액", dto);
 	}

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanController.java
@@ -1,12 +1,10 @@
 package com.wanted.moneyway.boundedContext.plan.controller;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,22 +12,23 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.wanted.moneyway.base.rsData.RsData;
-import com.wanted.moneyway.boundedContext.member.controller.ApiV1MemberController;
 import com.wanted.moneyway.boundedContext.plan.dto.PlanDTO;
 import com.wanted.moneyway.boundedContext.plan.entity.Plan;
 import com.wanted.moneyway.boundedContext.plan.service.PlanService;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/api/v1/plan")
 @Tag(name = "PlanController", description = "예산 계획 수립, 추천 컨트롤러")
+@SecurityRequirements({
+	@SecurityRequirement(name = "bearerAuth"),
+	@SecurityRequirement(name = "RefreshToken")
+})
 public class ApiV1PlanController {
 
 	private final PlanService planService;
@@ -37,7 +36,7 @@ public class ApiV1PlanController {
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("")
 	public RsData<List<Plan>> create(@RequestBody PlanDTO planDTO, @AuthenticationPrincipal User user) {
-		if(planDTO.checkAllZero())
+		if (planDTO.checkAllZero())
 			return RsData.of("F-1", "예산 항목 하나라도 입력 해야 등록 가능합니다.");
 
 		RsData<List<Plan>> rsData = planService.register(planDTO, user.getUsername());
@@ -47,8 +46,8 @@ public class ApiV1PlanController {
 
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/recommend")
-	public RsData<PlanDTO> recommend(@RequestParam Integer totalPrice, @AuthenticationPrincipal User user) {
-		if(totalPrice == null || totalPrice.equals(0)) {
+	public RsData<PlanDTO> recommend(@RequestParam Integer totalPrice) {
+		if (totalPrice == null || totalPrice.equals(0)) {
 			return RsData.of("F-1", "총 금액을 입력해주셔야 추천 가능합니다.");
 		}
 		PlanDTO dto = planService.recommend(totalPrice);

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanDTO.java
@@ -1,0 +1,21 @@
+package com.wanted.moneyway.boundedContext.plan.dto;
+
+import lombok.Data;
+
+@Data
+public class PlanDTO {
+	private int food = 0;
+	private int cafe = 0;
+	private int education = 0;
+	private int dwelling = 0; // 주거비
+	private int communication = 0; // 통신비
+	private int shopping = 0;
+	private int transfer = 0;
+	private int others = 0;
+
+	// 하나라도 값이 있어야 예산 설정 가능
+	public boolean checkAllZero() {
+		return food == 0 && cafe == 0 && education == 0 && dwelling == 0 &&
+			communication == 0 && shopping == 0 && transfer == 0 && others == 0;
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanDTO.java
@@ -1,8 +1,12 @@
 package com.wanted.moneyway.boundedContext.plan.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class PlanDTO {
 	private int food = 0;
 	private int cafe = 0;

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanPercentDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanPercentDTO.java
@@ -1,0 +1,19 @@
+package com.wanted.moneyway.boundedContext.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlanPercentDTO {
+	private Double food;
+	private Double cafe;
+	private Double education;
+	private Double dwelling; // 주거비
+	private Double communication; // 통신비
+	private Double shopping;
+	private Double transfer;
+	private Double others;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/entity/Plan.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/entity/Plan.java
@@ -29,4 +29,6 @@ public class Plan {
 
 	@ManyToOne
 	private Category category;
+
+	private Integer budget;
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/entity/Plan.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/entity/Plan.java
@@ -31,4 +31,6 @@ public class Plan {
 	private Category category;
 
 	private Integer budget;
+
+	private double categoryRatio;
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/CustomPlanRespository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/CustomPlanRespository.java
@@ -1,0 +1,7 @@
+package com.wanted.moneyway.boundedContext.plan.repository;
+
+import com.wanted.moneyway.boundedContext.plan.dto.PlanPercentDTO;
+
+public interface CustomPlanRespository {
+	PlanPercentDTO recommendPercent();
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/CustomPlanRespositoryImpl.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/CustomPlanRespositoryImpl.java
@@ -1,0 +1,49 @@
+package com.wanted.moneyway.boundedContext.plan.repository;
+
+import static com.wanted.moneyway.boundedContext.plan.entity.QPlan.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.moneyway.boundedContext.plan.dto.PlanPercentDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class CustomPlanRespositoryImpl implements CustomPlanRespository{
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public PlanPercentDTO recommendPercent() {
+
+		// 카테고리별 평균 비율
+		List<Tuple> results = jpaQueryFactory
+			.select(plan.category.nameE, plan.categoryRatio.avg())
+			.from(plan)
+			.groupBy(plan.category.id)
+			.fetch();
+		// DTO 객체 생성
+		PlanPercentDTO dto = new PlanPercentDTO();
+		for(Tuple t : results) {
+			String nameE = t.get(plan.category.nameE);
+			Double average = t.get(plan.categoryRatio.avg());
+
+			try {
+				// 속성명으로 메서드를 찾아내고, 값을 설정합니다.
+				// setter 메서드 호출하여 값 지정
+				Method method = dto.getClass().getMethod("set" + Character.toUpperCase(nameE.charAt(0)) + nameE.substring(1), Double.class);
+				method.invoke(dto, average);
+			} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+				// 로그를 남깁니다.
+				log.error("비율 계산 DTO 설정 예외 발생", e);
+			}
+		}
+		return dto;
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/PlanRepository.java
@@ -1,8 +1,12 @@
 package com.wanted.moneyway.boundedContext.plan.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.plan.entity.Plan;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+	List<Plan> findAllByMember(Member member);
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/PlanRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.plan.entity.Plan;
 
-public interface PlanRepository extends JpaRepository<Plan, Long> {
+public interface PlanRepository extends JpaRepository<Plan, Long>, CustomPlanRespository {
 	List<Plan> findAllByMember(Member member);
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
@@ -76,4 +76,9 @@ public class PlanService {
 
 		return RsData.of("S-1", "지출 계획 생성 완료", personalPlanList);
 	}
+
+	// TODO : 구현 필요
+	public PlanDTO recommend(Integer totalPrice) {
+
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
@@ -1,17 +1,23 @@
 package com.wanted.moneyway.boundedContext.plan.service;
 
+import static com.wanted.moneyway.boundedContext.plan.entity.QPlan.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.querydsl.core.Tuple;
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.service.CategoryService;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
 import com.wanted.moneyway.boundedContext.plan.dto.PlanDTO;
+import com.wanted.moneyway.boundedContext.plan.dto.PlanPercentDTO;
 import com.wanted.moneyway.boundedContext.plan.entity.Plan;
 import com.wanted.moneyway.boundedContext.plan.repository.PlanRepository;
 
@@ -27,6 +33,7 @@ public class PlanService {
 	private final CategoryService categoryService;
 
 	private final PlanRepository planRepository;
+
 	@Transactional
 	public RsData<List<Plan>> register(PlanDTO planDTO, String username) {
 		Member member = memberService.get(username);
@@ -41,6 +48,8 @@ public class PlanService {
 		int shopping = planDTO.getShopping();
 		int transfer = planDTO.getTransfer();
 		int others = planDTO.getOthers();
+
+		int sumBuget = cafe + dwelling + food + communication + education +shopping + transfer + others;
 
 		if(searchCategoryRs.isFail())
 			return (RsData) searchCategoryRs;
@@ -67,6 +76,7 @@ public class PlanService {
 				.category(c)
 				.budget(budget)
 				.member(member)
+				.categoryRatio((double)budget/sumBuget)
 				.build();
 
 			personalPlanList.add(p);
@@ -77,8 +87,29 @@ public class PlanService {
 		return RsData.of("S-1", "지출 계획 생성 완료", personalPlanList);
 	}
 
-	// TODO : 구현 필요
 	public PlanDTO recommend(Integer totalPrice) {
+		PlanPercentDTO planPercentDTO = planRepository.recommendPercent();
 
+		Integer food = (int) Math.ceil(totalPrice * planPercentDTO.getFood());
+		Integer cafe = (int) Math.ceil(totalPrice * planPercentDTO.getCafe());
+		Integer education = (int) Math.ceil(totalPrice * planPercentDTO.getEducation());
+		Integer dwelling = (int) Math.ceil(totalPrice * planPercentDTO.getDwelling());
+		Integer communication = (int) Math.ceil(totalPrice * planPercentDTO.getCommunication());
+		Integer shopping= (int) Math.ceil(totalPrice * planPercentDTO.getShopping());
+		Integer transfer = (int) Math.ceil(totalPrice * planPercentDTO.getTransfer());
+		Integer others = (int) Math.ceil(totalPrice * planPercentDTO.getOthers());
+
+		// DTO 객체 생성
+		PlanDTO dto = new PlanDTO();
+		dto.setCafe(cafe);
+		dto.setFood(food);
+		dto.setOthers(others);
+		dto.setDwelling(dwelling);
+		dto.setEducation(education);
+		dto.setCommunication(communication);
+		dto.setShopping(shopping);
+		dto.setTransfer(transfer);
+
+		return dto;
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
@@ -1,0 +1,79 @@
+package com.wanted.moneyway.boundedContext.plan.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.boundedContext.category.entity.Category;
+import com.wanted.moneyway.boundedContext.category.service.CategoryService;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.service.MemberService;
+import com.wanted.moneyway.boundedContext.plan.dto.PlanDTO;
+import com.wanted.moneyway.boundedContext.plan.entity.Plan;
+import com.wanted.moneyway.boundedContext.plan.repository.PlanRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class PlanService {
+
+	private final MemberService memberService;
+
+	private final CategoryService categoryService;
+
+	private final PlanRepository planRepository;
+	@Transactional
+	public RsData<List<Plan>> register(PlanDTO planDTO, String username) {
+		Member member = memberService.get(username);
+
+		RsData<List<Category>> searchCategoryRs = categoryService.getAll();
+
+		int cafe = planDTO.getCafe();
+		int dwelling = planDTO.getDwelling();
+		int food = planDTO.getFood();
+		int communication = planDTO.getCommunication();
+		int education = planDTO.getEducation();
+		int shopping = planDTO.getShopping();
+		int transfer = planDTO.getTransfer();
+		int others = planDTO.getOthers();
+
+		if(searchCategoryRs.isFail())
+			return (RsData) searchCategoryRs;
+
+		List<Category> categoryList = searchCategoryRs.getData();
+
+		List<Plan> personalPlanList = new ArrayList<>();
+
+		for(Category c : categoryList) {
+			int budget = 0;
+
+			switch (c.getNameE()) {
+				case "cafe" -> budget = cafe;
+				case "dwelling" -> budget = dwelling;
+				case "food" -> budget = food;
+				case "communication" -> budget = communication;
+				case "education" -> budget = education;
+				case "shopping" -> budget = shopping;
+				case "transfer" -> budget = transfer;
+				default -> budget = others;
+			}
+
+			Plan p = Plan.builder()
+				.category(c)
+				.budget(budget)
+				.member(member)
+				.build();
+
+			personalPlanList.add(p);
+		}
+
+		planRepository.saveAll(personalPlanList);
+
+		return RsData.of("S-1", "지출 계획 생성 완료", personalPlanList);
+	}
+}

--- a/src/test/java/com/wanted/moneyway/boundedContext/category/controller/ApiV1CategoryControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/category/controller/ApiV1CategoryControllerTest.java
@@ -63,6 +63,6 @@ public class ApiV1CategoryControllerTest {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.msg").value("카테고리 목록 조회 성공"))
-			.andExpect(jsonPath("$.data[0].name").value("교육"));
+			.andExpect(jsonPath("$.data[0].nameH").value("식비"));
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanControllertest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanControllertest.java
@@ -105,4 +105,33 @@ public class ApiV1PlanControllertest {
 			.andExpect(jsonPath("$.data[2].category.nameE").value("education"))
 			.andExpect(jsonPath("$.data[2].budget").value(0));
 	}
+
+	@Test
+	@DisplayName("POST /api/v1/plan/recommend 은 예산 추천 URL로 총액을 입력하면 예산별 금액을 추천해준다.")
+	void t3() throws Exception {
+		// "user1"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user1");
+		String token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/api/v1/plan/recommend")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+					.content("""
+						{
+						    "totalPrice": "1000000"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("항목별 추천 금액"))
+			.andExpect(jsonPath("$.data.food").value("125000"))
+			.andExpect(jsonPath("$.data.cafe").value("125000"));
+	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanControllertest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/plan/controller/ApiV1PlanControllertest.java
@@ -1,0 +1,108 @@
+package com.wanted.moneyway.boundedContext.plan.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wanted.moneyway.base.jwt.JwtProvider;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.service.MemberService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class ApiV1PlanControllertest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Test
+	@DisplayName("POST /api/v1/plan 은 예산 등록 URL 이다.")
+	void t1() throws Exception {
+		// "user1"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user1");
+		String token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/api/v1/plan")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+					.content("""
+						{
+						    "food": "100000",
+						    "cafe": "50000",
+						    "education" : "100000",
+						    "dwelling" : "300000",
+						    "communication" : "100000",
+						    "shopping" : "30000",
+						    "transfer" : "100000",
+						    "others" : "300000"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("지출 계획 생성 완료"))
+			.andExpect(jsonPath("$.data[0].budget").value(100_000));
+	}
+
+	@Test
+	@DisplayName("POST /api/v1/plan 은 예산 등록 URL로 일부 속성만 입력해도 나머지는 0원으로 자동 입력된다.")
+	void t2() throws Exception {
+		// "user1"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user1");
+		String token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/api/v1/plan")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+					.content("""
+						{
+						    "food": "100000",
+						    "cafe": "50000",
+						    "dwelling" : "300000",
+						    "communication" : "100000",
+						    "shopping" : "30000",
+						    "transfer" : "100000",
+						    "others" : "300000"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("지출 계획 생성 완료"))
+			.andExpect(jsonPath("$.data[2].category.nameE").value("education"))
+			.andExpect(jsonPath("$.data[2].budget").value(0));
+	}
+}


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #9 
### 📑 개요
- 목표 예산 설정 기능
- 예산 추천 기능
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **build.gradle**
  - queryDsl, p6spy 의존성 추가
- **src/main/java/com/wanted/moneyway/boundedContext/category/entity/Category.java**
  - 카테고리 영문 이름과 한글 이름 모두 저장하도록 수정

- **src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanDTO.java**
  - 예산 설정에 사용하는 DTO 파일로 각 카테고리별 예산 설정 입력
   - 입력하지 않으면 기본값은 0원으로 설정
   - checkAllZero() : 모두 입력하지 않으면 저장 되지 않도록 하기 위한 체크 메서드

- **src/main/java/com/wanted/moneyway/boundedContext/plan/dto/PlanPercentDTO.java**
  - QueryDsl로 카테고리별 평균값을 옮기기 위한 DTO 객체 정의

- **src/main/java/com/wanted/moneyway/boundedContext/plan/entity/Plan.java**
  - 예산 금액, 전체 예산 중 특정 카테고리가 차지하는 비율 속성 추가

- **src/main/java/com/wanted/moneyway/boundedContext/plan/repository/CustomPlanRespositoryImpl.java**
  - recommendPercent() : 카테고리별 평균 비용 반환
      -  **Java Reflection API를 사용**하여 동적으로 Setter 메서드를 호출하여 각 튜플에 저장된 평균값을 DTO 객체에 값 지정

- **src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java**

  - register() : 사용자 예산 계획 객체 생성 메서드
      - **예산 계획 테이블에 속성으로 카테고리가 있는 것이 아니라 카테고리 속성 안에 있어 하드코딩 불가피**
      - **더 나은 방향 고민 후 리팩토링 예정**

   - recommend() : 총 예산을 입력받아 추천금액 반환 메서드

## 📷 스크린샷

## 👀 기타
- 다음 PR시 예산 수정과 불필요 import와 Optimizer Code 한번 수행 같이 예정
- 하드 코딩한 부분 메서드화 고민