### PR TITLE
[Feat] 지출 내역 생성 및 삭제 기능 구현

### DIFF
--- a/src/main/generated/com/wanted/moneyway/boundedContext/expenditure/entity/QExpenditure.java
+++ b/src/main/generated/com/wanted/moneyway/boundedContext/expenditure/entity/QExpenditure.java
@@ -32,7 +32,7 @@ public class QExpenditure extends EntityPathBase<Expenditure> {
 
     public final StringPath memo = createString("memo");
 
-    public final DateTimePath<java.time.LocalDateTime> spendDate = createDateTime("spendDate", java.time.LocalDateTime.class);
+    public final DatePath<java.time.LocalDate> spendDate = createDate("spendDate", java.time.LocalDate.class);
 
     public final NumberPath<Integer> spendingPrice = createNumber("spendingPrice", Integer.class);
 

--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -1,5 +1,6 @@
 package com.wanted.moneyway.base.initData;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,6 +12,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.repository.CategoryRepository;
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+import com.wanted.moneyway.boundedContext.expenditure.repository.ExpenditureRepository;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.repository.MemberRepository;
 import com.wanted.moneyway.boundedContext.plan.dto.PlanDTO;
@@ -21,7 +24,7 @@ import com.wanted.moneyway.boundedContext.plan.service.PlanService;
 public class NotProd {
 	@Bean
 	CommandLineRunner initData(MemberRepository memberRepository, PasswordEncoder passwordEncoder,
-		CategoryRepository categoryRepository, PlanService planService) {
+		CategoryRepository categoryRepository, PlanService planService, ExpenditureRepository expenditureRepository) {
 		return args -> {
 			String password = passwordEncoder.encode("1234");
 			List<Member> memberList = new ArrayList<>();
@@ -110,6 +113,38 @@ public class NotProd {
 			planService.register(planDTO1, user1.getUserName());
 			planService.register(planDTO1, user2.getUserName());
 			planService.register(planDTO1, user3.getUserName());
+
+			List<Expenditure> expenditureList = new ArrayList<>();
+
+			Expenditure expenditure1 = Expenditure.builder()
+				.member(user1)
+				.category(category1)
+				.memo("식당 내기 짐")
+				.spendingPrice(10_000)
+				.spendDate(LocalDate.of(2023, 11, 01))
+				.build();
+
+			Expenditure expenditure2 = Expenditure.builder()
+				.member(user1)
+				.category(category1)
+				.memo("식당 내기 짐")
+				.spendingPrice(10_000)
+				.spendDate(LocalDate.of(2023, 11, 02))
+				.build();
+
+			Expenditure expenditure3 = Expenditure.builder()
+				.member(user1)
+				.category(category1)
+				.memo("식당 내기 짐")
+				.spendingPrice(10_000)
+				.spendDate(LocalDate.of(2023, 11, 03))
+				.build();
+
+			expenditureList.add(expenditure1);
+			expenditureList.add(expenditure2);
+			expenditureList.add(expenditure3);
+
+			expenditureRepository.saveAll(expenditureList);
 
 
 		};

--- a/src/main/java/com/wanted/moneyway/boundedContext/category/service/CategoryService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/category/service/CategoryService.java
@@ -25,4 +25,8 @@ public class CategoryService {
 
 		return RsData.of("S-1", "카테고리 목록 조회 성공", allCategories);
 	}
+
+	public Category get(Long categoryId) {
+		return categoryRepository.findById(categoryId).get();
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -1,0 +1,45 @@
+package com.wanted.moneyway.boundedContext.expenditure.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+import com.wanted.moneyway.boundedContext.expenditure.service.ExpenditureService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/api/v1/expenditure")
+@Tag(name = "ExpenditureController", description = "지출 컨트롤러")
+@SecurityRequirements({
+	@SecurityRequirement(name = "bearerAuth"),
+	@SecurityRequirement(name = "RefreshToken")
+})
+public class ApiV1ExpenditureController {
+
+	private final ExpenditureService expenditureService;
+
+	@PreAuthorize("isAuthenticated()")
+	@PostMapping("/create")
+	@Operation(summary = "지출 내역 저장")
+	public RsData create(@RequestBody ExpenditureDTO expenditureDTO, @AuthenticationPrincipal User user) {
+		RsData<Expenditure> rsCreate = expenditureService.create(expenditureDTO, user.getUsername());
+		if (rsCreate.isFail())
+			return rsCreate;
+
+		return RsData.of(rsCreate.getResultCode(), rsCreate.getMsg(), ExpenditureDTO.of(rsCreate.getData()));
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -33,7 +33,7 @@ public class ApiV1ExpenditureController {
 	private final ExpenditureService expenditureService;
 
 	@PreAuthorize("isAuthenticated()")
-	@PostMapping("/create")
+	@PostMapping("")
 	@Operation(summary = "지출 내역 저장")
 	public RsData create(@RequestBody ExpenditureDTO expenditureDTO, @AuthenticationPrincipal User user) {
 		RsData<Expenditure> rsCreate = expenditureService.create(expenditureDTO, user.getUsername());

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -3,6 +3,7 @@ package com.wanted.moneyway.boundedContext.expenditure.controller;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,9 +16,12 @@ import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.expenditure.service.ExpenditureService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -42,4 +46,21 @@ public class ApiV1ExpenditureController {
 
 		return RsData.of(rsCreate.getResultCode(), rsCreate.getMsg(), ExpenditureDTO.of(rsCreate.getData()));
 	}
+
+	@Data
+	public static class DeleteRequest {
+		@NotBlank(message = "삭제 지출 내역 id를 입력해주세요")
+		@Schema(description = "지출 내역 id", example = "1")
+		private Long expenditureId;
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@DeleteMapping("")
+	@Operation(summary = "지출 내역 삭제")
+	public RsData delete(@RequestBody DeleteRequest deleteRequest, @AuthenticationPrincipal User user) {
+		RsData rsDelete = expenditureService.delete(deleteRequest.getExpenditureId(), user.getUsername());
+
+		return rsDelete;
+	}
+
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ExpenditureDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ExpenditureDTO.java
@@ -1,0 +1,45 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import static java.lang.Boolean.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenditureDTO {
+	@NotNull(message = "카테고리 Id를 입력해주세요")
+	@Schema(description = "카테고리 Id 입력", example = "1")
+	private Long categoryId;
+	@NotNull(message = "소비 금액을 입력해주세요.")
+	@Schema(description = "소비 금액, 천단위 구분기호 없이", example = "10000")
+	private Integer spendingPrice;
+	@Schema(description = "비고란", example = "식당 내기 짐")
+	private String memo;
+	@NotNull(message = "지출 일자를 입력해주세요")
+	@Schema(description = "지출 일자 형식")
+	private LocalDate spendDate;
+	@Schema(description = "지출 합계에 포함 시킬지 여부(기본값 true)", example = "true(기본값) / false")
+	private Boolean isTotal = TRUE;
+
+	public static ExpenditureDTO of(Expenditure expenditure) {
+		return ExpenditureDTO.builder()
+			.categoryId(expenditure.getCategory().getId())
+			.isTotal(expenditure.getIsTotal())
+			.memo(expenditure.getMemo())
+			.spendDate(expenditure.getSpendDate())
+			.spendingPrice(expenditure.getSpendingPrice())
+			.build();
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/entity/Expenditure.java
@@ -2,8 +2,9 @@ package com.wanted.moneyway.boundedContext.expenditure.entity;
 
 import static jakarta.persistence.GenerationType.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
+import com.querydsl.core.annotations.QueryEntity;
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@QueryEntity
 public class Expenditure {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -30,7 +32,7 @@ public class Expenditure {
 
 	private String memo;
 
-	private LocalDateTime spendDate;
+	private LocalDate spendDate;
 
 	private Boolean isTotal;
 

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/entity/Expenditure.java
@@ -1,6 +1,7 @@
 package com.wanted.moneyway.boundedContext.expenditure.entity;
 
 import static jakarta.persistence.GenerationType.*;
+import static java.lang.Boolean.*;
 
 import java.time.LocalDate;
 
@@ -34,7 +35,8 @@ public class Expenditure {
 
 	private LocalDate spendDate;
 
-	private Boolean isTotal;
+	@Builder.Default
+	private Boolean isTotal = TRUE;
 
 	@ManyToOne
 	private Member member;

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -1,0 +1,51 @@
+package com.wanted.moneyway.boundedContext.expenditure.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.boundedContext.category.entity.Category;
+import com.wanted.moneyway.boundedContext.category.service.CategoryService;
+import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+import com.wanted.moneyway.boundedContext.expenditure.repository.ExpenditureRepository;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExpenditureService {
+
+	private final ExpenditureRepository expenditureRepository;
+	private final MemberService memberService;
+
+	private final CategoryService categoryService;
+
+	@Transactional
+	public RsData<Expenditure> create(ExpenditureDTO expenditureDTO, String username) {
+		Member member = memberService.get(username);
+
+		Category category = categoryService.get(expenditureDTO.getCategoryId());
+
+		if(category == null) {
+			return RsData.of("F-1", "해당 카테고리는 존재하지 않습니다.");
+		}
+
+		Expenditure expenditure = Expenditure.builder()
+			.memo(expenditureDTO.getMemo())
+			.isTotal(expenditureDTO.getIsTotal())
+			.spendDate(expenditureDTO.getSpendDate())
+			.category(category)
+			.spendingPrice(expenditureDTO.getSpendingPrice())
+			.member(member)
+			.build();
+
+		expenditureRepository.save(expenditure);
+
+		return RsData.of("S-1", "지출 정보 저장 성공", expenditure);
+
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.service.CategoryService;
+import com.wanted.moneyway.boundedContext.expenditure.controller.ApiV1ExpenditureController;
 import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.expenditure.repository.ExpenditureRepository;
@@ -47,5 +48,21 @@ public class ExpenditureService {
 
 		return RsData.of("S-1", "지출 정보 저장 성공", expenditure);
 
+	}
+
+	@Transactional
+	public RsData delete(Long expenditureId, String username) {
+		Member member = memberService.get(username);
+
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).get();
+
+		if(expenditure == null)
+			return RsData.of("F-1", "이미 삭제된 지출 내역입니다.");
+		if(!expenditure.getMember().equals(member))
+			return RsData.of("F-1", "내역 작성한 사용자만 삭제 가능합니다.");
+
+		expenditureRepository.delete(expenditure);
+
+		return RsData.of("S-1", "삭제 성공");
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,5 +74,57 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.data.categoryId").value(1))
 			.andExpect(jsonPath("$.data.spendingPrice").value(10_000))
 			.andExpect(jsonPath("$.data.memo").value("식당 내기 짐"));
+	}
+
+	@Test
+	@DisplayName("DELETE /api/v1/expenditure 은 지출 내역을 삭제한다.")
+	void t2() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				delete("/api/v1/expenditure")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+					.content("""
+						{
+							  "expenditureId": "1"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("삭제 성공"));
+	}
+
+	@Test
+	@DisplayName("DELETE /api/v1/expenditure 은 작성자만 지출 내역을 삭제가 가능하다")
+	void t3() throws Exception {
+		// "user3"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user3");
+		token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				delete("/api/v1/expenditure")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+					.content("""
+						{
+							  "expenditureId": "1"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("내역 작성한 사용자만 삭제 가능합니다."));
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -1,0 +1,79 @@
+package com.wanted.moneyway.boundedContext.expenditure;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.wanted.moneyway.base.jwt.JwtProvider;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.service.MemberService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class ExpenditureControllerTest {
+
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Autowired
+	private MockMvc mvc;
+
+	String token;
+	@BeforeEach
+	void setToken() {
+		// "user1"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user1");
+		token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+	}
+
+	@Test
+	@DisplayName("POST /api/v1/expenditure 은 지출 내역을 추가한다.")
+	void t1() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				post("/api/v1/expenditure")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+					.content("""
+						{
+							  "categoryId": "1",
+							  "spendingPrice": "10000",
+							  "memo": "식당 내기 짐",
+							  "spendDate": "2023-11-14",
+							  "isTotal": "false"
+						}
+						""".stripIndent())
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("지출 정보 저장 성공"))
+			.andExpect(jsonPath("$.data.categoryId").value(1))
+			.andExpect(jsonPath("$.data.spendingPrice").value(10_000))
+			.andExpect(jsonPath("$.data.memo").value("식당 내기 짐"));
+	}
+}


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #14 
### 📑 개요
지출 내역 생성 및 삭제 기능을 구현합니다.
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java**
  - 지출 내역 저장 및 삭제 API 엔드포인트 생성

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ExpenditureDTO.java**
  - 지출 내역 저장 및 반환용 DTO 객체 생성

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/entity/Expenditure.java**
  - 지출일자 LocalDate로 저장 형식 변경(일 시는 저장 안해도 될 것 같기에)
   - Builder 패턴 isTotal 기본값으로 true 설정 -> 별도 설정 안하면 합계에 포함 되게 설정용

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - create() : 지출 내역 생성
   - delete() : 본인이 쓴 지출 내역인지 검사하고 삭제

## 📷 스크린샷

## 👀 기타
- 지출 내역 조회는 다음 PR에서 진행합니다.
