### PR TITLE
[Feat] 지출 내역 상세, 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -153,9 +153,28 @@ public class NotProd {
 			expenditureList.add(expenditure3);
 			expenditureList.add(expenditure4);
 
+			for (int i = 1; i <= 10; i++) {
+				Expenditure expenditureTest1 = Expenditure.builder()
+					.member(user1)
+					.category(category1)
+					.memo("테스트 식비" + i)
+					.spendingPrice(10_000)
+					.spendDate(LocalDate.now())
+					.build();
+
+				Expenditure expenditureTest2 = Expenditure.builder()
+					.member(user1)
+					.category(category2)
+					.memo("테스트 카페/간식" + i)
+					.spendingPrice(10_000)
+					.spendDate(LocalDate.now())
+					.build();
+
+				expenditureList.add(expenditureTest1);
+				expenditureList.add(expenditureTest2);
+			}
+
 			expenditureRepository.saveAll(expenditureList);
-
-
 		};
 	}
 }

--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -140,9 +140,18 @@ public class NotProd {
 				.spendDate(LocalDate.of(2023, 11, 03))
 				.build();
 
+			Expenditure expenditure4 = Expenditure.builder()
+				.member(user2)
+				.category(category1)
+				.memo("식당 내기 짐")
+				.spendingPrice(10_000)
+				.spendDate(LocalDate.of(2023, 11, 04))
+				.build();
+
 			expenditureList.add(expenditure1);
 			expenditureList.add(expenditure2);
 			expenditureList.add(expenditure3);
+			expenditureList.add(expenditure4);
 
 			expenditureRepository.saveAll(expenditureList);
 

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -4,6 +4,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -61,6 +63,17 @@ public class ApiV1ExpenditureController {
 		RsData rsDelete = expenditureService.delete(deleteRequest.getExpenditureId(), user.getUsername());
 
 		return rsDelete;
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("{id}")
+	@Operation(summary = "상세 지출 내역 조회")
+	public RsData expenditures(@AuthenticationPrincipal User user, @PathVariable Long id) {
+		RsData<Expenditure> rsRead = expenditureService.get(user.getUsername(), id);
+		if (rsRead.isFail())
+			return rsRead;
+
+		return RsData.of(rsRead.getResultCode(), rsRead.getMsg(), ExpenditureDTO.of(rsRead.getData()));
 	}
 
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -1,10 +1,13 @@
 package com.wanted.moneyway.boundedContext.expenditure.controller;
 
+import java.time.LocalDate;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.SearchResult;
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.expenditure.service.ExpenditureService;
 
@@ -69,11 +74,40 @@ public class ApiV1ExpenditureController {
 	@GetMapping("{id}")
 	@Operation(summary = "상세 지출 내역 조회")
 	public RsData expenditures(@AuthenticationPrincipal User user, @PathVariable Long id) {
-		RsData<Expenditure> rsRead = expenditureService.get(user.getUsername(), id);
+		RsData<Expenditure> rsRead = expenditureService.search(user.getUsername(), id);
 		if (rsRead.isFail())
 			return rsRead;
 
 		return RsData.of(rsRead.getResultCode(), rsRead.getMsg(), ExpenditureDTO.of(rsRead.getData()));
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("")
+	@Operation(summary = "지출 내역 목록 조회")
+	public RsData<SearchResult> search(
+		@RequestParam(required = false, defaultValue = "#{T(java.time.LocalDate).now().minusDays(7)}") LocalDate startDate,
+		@RequestParam(required = false, defaultValue = "#{T(java.time.LocalDate).now()}") LocalDate endDate,
+		@RequestParam(required = false) Long categoryId,
+		@RequestParam(required = false) Integer minPrice,
+		@RequestParam(required = false) Integer maxPrice,
+		@RequestParam(required = false, defaultValue = "0") Integer pageNumber,
+		@RequestParam(required = false, defaultValue = "10") Integer pageLimit,
+		@AuthenticationPrincipal User user) {
+
+		SearchRequestDTO searchRequestDTO = SearchRequestDTO
+			.builder()
+			.startDate(startDate)
+			.endDate(endDate)
+			.categoryId(categoryId)
+			.minPrice(minPrice)
+			.maxPrice(maxPrice)
+			.pageLimit(pageLimit)
+			.pageNumber(pageNumber)
+			.build();
+
+		System.out.println(searchRequestDTO);
+		RsData<SearchResult> rsSearch = expenditureService.search(user.getUsername(), searchRequestDTO);
+		return rsSearch;
 	}
 
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySum.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySum.java
@@ -1,0 +1,14 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategorySum {
+	private Long categoryId;
+	private String categoryName;
+	private Integer spending;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ExpenditureDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ExpenditureDTO.java
@@ -19,6 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExpenditureDTO {
+	@Schema(description = "지출내역 id, 응답용 필드", accessMode = Schema.AccessMode.READ_ONLY)
+	private Long expenditureId;
 	@NotNull(message = "카테고리 Id를 입력해주세요")
 	@Schema(description = "카테고리 Id 입력", example = "1")
 	private Long categoryId;
@@ -35,6 +37,7 @@ public class ExpenditureDTO {
 
 	public static ExpenditureDTO of(Expenditure expenditure) {
 		return ExpenditureDTO.builder()
+			.expenditureId(expenditure.getId())
 			.categoryId(expenditure.getCategory().getId())
 			.isTotal(expenditure.getIsTotal())
 			.memo(expenditure.getMemo())

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/SearchRequestDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/SearchRequestDTO.java
@@ -1,0 +1,34 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SearchRequestDTO {
+
+	@Schema(description = "조회 시작일을 입력해주세요(기본값 : 7일 전)", example = "2023-11-07")
+	private LocalDate startDate = LocalDate.now().minusDays(7);
+	@Schema(description = "조회 종료일을 입력해주세요(기본값 : 오늘)", example = "2023-11-14")
+	private LocalDate endDate = LocalDate.now();
+
+	@Schema(description = "조회 카테고리 Id를 입력해주세요(기본값 : 전체 데이터)", example = "2")
+	private Long categoryId = null;
+	@Schema(description = "조회 최소 금액을 입력해주세요(미입력 시 금액 상관 없이 전체 조회)", example = "3000")
+	private Integer minPrice = -1;
+	@Schema(description = "조회 최대 금액을 입력해주세요(미입력 시 금액 상관 없이 전체 조회)", example = "500000")
+	private Integer maxPrice = -1;
+
+	@Schema(description = "조회할 페이지 번호를 입력해주세요(기본값 : 0)", example = "0")
+	private Integer pageNumber = 0;
+
+	@Schema(description = "페이지당 조회할 지출 내역을 입력해주세요(기본값 : 10)", example = "10")
+	private Integer pageLimit = 10;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/SearchResult.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/SearchResult.java
@@ -1,0 +1,20 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchResult {
+	private Integer totalSpending;
+	private List<CategorySum> spendingByCategory;
+	private Page<Expenditure> expenditures;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TotalAndCategorySumDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TotalAndCategorySumDTO.java
@@ -1,0 +1,15 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TotalAndCategorySumDTO {
+	private Integer totalSpending;
+	private List<CategorySum> categorySumList;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.moneyway.boundedContext.expenditure.repository;
+
+import org.springframework.data.domain.Page;
+
+import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndCategorySumDTO;
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+
+public interface CustomExpenditureRepository {
+	Page<Expenditure> searchExpenditure(Member member, SearchRequestDTO searchRequestDTO);
+
+	TotalAndCategorySumDTO getTotalAndCategorySum(Member member, SearchRequestDTO searchRequestDTO);
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepositoryImpl.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepositoryImpl.java
@@ -1,0 +1,156 @@
+package com.wanted.moneyway.boundedContext.expenditure.repository;
+
+import static com.wanted.moneyway.boundedContext.category.entity.QCategory.*;
+import static com.wanted.moneyway.boundedContext.expenditure.entity.QExpenditure.*;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.moneyway.boundedContext.expenditure.dto.CategorySum;
+import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndCategorySumDTO;
+import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomExpenditureRepositoryImpl implements CustomExpenditureRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	/*
+		페이지별 지출 데이터 조회
+	 */
+	@Override
+	public Page<Expenditure> searchExpenditure(Member member, SearchRequestDTO searchRequestDTO) {
+		LocalDate startDate = searchRequestDTO.getStartDate();
+		LocalDate endDate = searchRequestDTO.getEndDate();
+		Long categoryId = searchRequestDTO.getCategoryId();
+		Integer minPrice = searchRequestDTO.getMinPrice();
+		Integer maxPrice = searchRequestDTO.getMaxPrice();
+
+		Integer pageNumber = searchRequestDTO.getPageNumber();
+		Integer pageLimit = searchRequestDTO.getPageLimit();
+
+		Pageable pageable = PageRequest.of(pageNumber, pageLimit);
+
+		// 여러 조건을 동적으로 추가할 수 있도록 도와주는 BooleanBuilder 도입
+		BooleanBuilder builder = createBooleanBuilder(categoryId, minPrice, maxPrice);
+
+		// 조건에 맞는 목록 구하기
+		List<Expenditure> expenditures = jpaQueryFactory.selectFrom(expenditure)
+			.where(
+				expenditure.member.eq(member),
+				expenditure.spendDate.between(startDate, endDate),
+				builder // 조건 동적 추가
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		// 전체 데이터 개수 추출
+		long total = jpaQueryFactory.selectFrom(expenditure)
+			.where(
+				expenditure.member.eq(member),
+				expenditure.spendDate.between(startDate, endDate),
+				builder // 조건 동적 추가
+			)
+			.fetchCount();
+
+		return new PageImpl<>(expenditures, pageable, total);
+	}
+
+	/*
+		총 합계 금액, 각 카테고리별 합계 금액 추출
+	 */
+	@Override
+	public TotalAndCategorySumDTO getTotalAndCategorySum(Member member, SearchRequestDTO searchRequestDTO) {
+		LocalDate startDate = searchRequestDTO.getStartDate();
+		LocalDate endDate = searchRequestDTO.getEndDate();
+		Long categoryId = searchRequestDTO.getCategoryId();
+		Integer minPrice = searchRequestDTO.getMinPrice();
+		Integer maxPrice = searchRequestDTO.getMaxPrice();
+
+		// 여러 조건을 동적으로 추가할 수 있도록 도와주는 BooleanBuilder 도입
+		BooleanBuilder builder = createBooleanBuilder(categoryId, minPrice, maxPrice);
+
+		// 조건에 맞는 지출 리스트 추출
+		List<Expenditure> expenditures = jpaQueryFactory.selectFrom(expenditure)
+			.where(
+				expenditure.member.eq(member),
+				expenditure.spendDate.between(startDate, endDate),
+				expenditure.isTotal.eq(true),
+				builder // 조건 동적 추가
+			)
+			.fetch();
+
+		// 지출 합계 계산
+		Integer totalSpending = 0;
+		for (Expenditure expenditure : expenditures) {
+			totalSpending += expenditure.getSpendingPrice();
+		}
+
+		// 카테고리별 지출 합계 추출용 map
+		Map<Long, Integer> categorySums = new HashMap<>();
+		for (Expenditure expenditure : expenditures) {
+			Long targetCategoryId = expenditure.getCategory().getId();
+			categorySums.put(targetCategoryId,
+				categorySums.getOrDefault(targetCategoryId, 0) + expenditure.getSpendingPrice());
+		}
+
+		List<CategorySum> categorySumList = categorySums.entrySet().stream()
+			.map(entry -> new CategorySum(
+				entry.getKey(), // id 추출
+				getCategoryNameH(entry.getKey()), // 이름 추출
+				entry.getValue() // 합계 추출
+			))
+			.collect(Collectors.toList());
+
+		return new TotalAndCategorySumDTO(totalSpending, categorySumList);
+	}
+
+	/*
+		카테고리 한글 이름 추출 메서드
+	 */
+	private String getCategoryNameH(Long findCategoryId) {
+		return jpaQueryFactory
+			.select(category.nameH)
+			.from(category)
+			.where(category.id.eq(findCategoryId))
+			.fetchOne();
+	}
+
+	private BooleanBuilder createBooleanBuilder(Long categoryId, Integer minPrice, Integer maxPrice) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 카테고리 입력 시에만 조건 적용되도록
+		if (categoryId != null) {
+			builder.and(expenditure.category.id.eq(categoryId));
+		}
+
+		// case 1. 최소, 최대 금액 범위가 입력된 경우 // 이 경우 minPrice ~ maxPrice 조건 추가
+		if (minPrice != null && maxPrice != null) {
+			builder.and(expenditure.spendingPrice.between(minPrice, maxPrice));
+		}
+		// case 2. 최소 금액 범위만 입력된 경우 // 이 경우 minPrice 이상인 조건 추가
+		else if (minPrice != null) {
+			builder.and(expenditure.spendingPrice.goe(minPrice));
+		}
+		// case 3. 최대 금액 범위만 입력된 경우 -> 이 경우 maxPrice 이하인 조건 추가
+		else if (maxPrice != null) {
+			builder.and(expenditure.spendingPrice.loe(maxPrice));
+		}
+
+		return builder;
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/ExpenditureRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/ExpenditureRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 
-public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>  {
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, CustomExpenditureRepository  {
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -65,4 +65,20 @@ public class ExpenditureService {
 
 		return RsData.of("S-1", "삭제 성공");
 	}
+/*
+	userName과 expeditureId를 받아 지출 내역을 반환하는 메서드
+ */
+	public RsData<Expenditure> get(String userName, Long expenditureId) {
+		Member member = memberService.get(userName);
+
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).get();
+
+		if(expenditure == null)
+			return RsData.of("F-1", "존재하지 않는 내역입니다.");
+
+		if(!expenditure.getMember().equals(member))
+			return RsData.of("F-1", "지출 내역 작성자가 아닙니다.");
+
+		return RsData.of("S-1", "내역 조회 성공", expenditure);
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -13,6 +13,7 @@ import com.wanted.moneyway.boundedContext.expenditure.repository.ExpenditureRepo
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
 
+import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -54,10 +55,10 @@ public class ExpenditureService {
 	public RsData delete(Long expenditureId, String username) {
 		Member member = memberService.get(username);
 
-		Expenditure expenditure = expenditureRepository.findById(expenditureId).get();
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).orElse(null);
 
 		if(expenditure == null)
-			return RsData.of("F-1", "이미 삭제된 지출 내역입니다.");
+			return RsData.of("F-1", "이미 삭제되었거나 존재하지 않는 내역입니다.");
 		if(!expenditure.getMember().equals(member))
 			return RsData.of("F-1", "내역 작성한 사용자만 삭제 가능합니다.");
 
@@ -71,10 +72,10 @@ public class ExpenditureService {
 	public RsData<Expenditure> get(String userName, Long expenditureId) {
 		Member member = memberService.get(userName);
 
-		Expenditure expenditure = expenditureRepository.findById(expenditureId).get();
+		Expenditure expenditure = expenditureRepository.findById(expenditureId).orElse(null);
 
 		if(expenditure == null)
-			return RsData.of("F-1", "존재하지 않는 내역입니다.");
+			return RsData.of("F-1", "이미 삭제되었거나 존재하지 않는 내역입니다.");
 
 		if(!expenditure.getMember().equals(member))
 			return RsData.of("F-1", "지출 내역 작성자가 아닙니다.");

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -1,19 +1,23 @@
 package com.wanted.moneyway.boundedContext.expenditure.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.service.CategoryService;
-import com.wanted.moneyway.boundedContext.expenditure.controller.ApiV1ExpenditureController;
 import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.SearchResult;
+import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndCategorySumDTO;
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.expenditure.repository.ExpenditureRepository;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
 
-import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -69,7 +73,7 @@ public class ExpenditureService {
 /*
 	userName과 expeditureId를 받아 지출 내역을 반환하는 메서드
  */
-	public RsData<Expenditure> get(String userName, Long expenditureId) {
+	public RsData<Expenditure> search(String userName, Long expenditureId) {
 		Member member = memberService.get(userName);
 
 		Expenditure expenditure = expenditureRepository.findById(expenditureId).orElse(null);
@@ -81,5 +85,18 @@ public class ExpenditureService {
 			return RsData.of("F-1", "지출 내역 작성자가 아닙니다.");
 
 		return RsData.of("S-1", "내역 조회 성공", expenditure);
+	}
+
+	public RsData search(String userName, SearchRequestDTO searchRequestDTO) {
+		Member member = memberService.get(userName);
+
+		Page<Expenditure> expenditurePage = expenditureRepository.searchExpenditure(member, searchRequestDTO);
+		TotalAndCategorySumDTO totalAndCategorySum = expenditureRepository.getTotalAndCategorySum(member,
+			searchRequestDTO);
+
+		SearchResult searchResult = new SearchResult(totalAndCategorySum.getTotalSpending(),
+			totalAndCategorySum.getCategorySumList(), expenditurePage);
+
+		return RsData.of("S-1", "조회 성공", searchResult);
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -126,5 +127,65 @@ public class ExpenditureControllerTest {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(jsonPath("$.resultCode").value("F-1"))
 			.andExpect(jsonPath("$.msg").value("내역 작성한 사용자만 삭제 가능합니다."));
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/expenditure/{id} 는 사용자가 작성한 지출 내역의 상세 내용을 반환한다.")
+	void t4() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/1")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("내역 조회 성공"))
+			.andExpect(jsonPath("$.data.expenditureId").value(1))
+			.andExpect(jsonPath("$.data.categoryId").value(1))
+			.andExpect(jsonPath("$.data.spendingPrice").value(10000))
+			.andExpect(jsonPath("$.data.memo").value("식당 내기 짐"))
+			.andExpect(jsonPath("$.data.spendDate").value("2023-11-01"))
+			.andExpect(jsonPath("$.data.isTotal").value(true));
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/expenditure/{id} 는 다른 사용자가 작성한 내역을 검사할 수 없다.")
+	void t5() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/4")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("지출 내역 작성자가 아닙니다."));
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/expenditure/{id} 는 삭제되었거나 존재하지 않는 지출내역의 정보를 조회할 수 없다.")
+	void t6() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/1052")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("F-1"))
+			.andExpect(jsonPath("$.msg").value("이미 삭제되었거나 존재하지 않는 내역입니다."));
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -188,4 +188,49 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.resultCode").value("F-1"))
 			.andExpect(jsonPath("$.msg").value("이미 삭제되었거나 존재하지 않는 내역입니다."));
 	}
+
+	@Test
+	@DisplayName("GET /api/v1/expenditure 는 전체 지출 총액, 카테고리별 지출 총액 조회가 가능하다")
+	void t7_1() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("조회 성공"))
+			.andExpect(jsonPath("$.data.totalSpending").value("200000"))
+			.andExpect(jsonPath("$.data.spendingByCategory[0].categoryName").value("식비"))
+			.andExpect(jsonPath("$.data.spendingByCategory[0].spending").value(100000))
+			.andExpect(jsonPath("$.data.spendingByCategory[1].categoryName").value("카페/간식"))
+			.andExpect(jsonPath("$.data.spendingByCategory[1].spending").value(100000));
+	}
+
+	@Test
+	@DisplayName("GET /api/v1/expenditure 는 위 테스트에서 금액 뿐 아니라 카테고리별 지출 내역 역시 조회가 가능하다")
+	void t7_2() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("조회 성공"))
+			.andExpect(jsonPath("$.data.expenditures.content[0].memo").value("테스트 식비1"))
+			.andExpect(jsonPath("$.data.expenditures.content[0].spendingPrice").value(10_000))
+			.andExpect(jsonPath("$.data.expenditures.content[1].memo").value("테스트 카페/간식1"))
+			.andExpect(jsonPath("$.data.expenditures.content[1].spendingPrice").value(10_000));
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️관련 이슈[#]
close #16 
### 📑 개요
- 지출 내역 상세 조회, 목록 조회를 구현합니다.
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/moneyway/base/initData/NotProd.java**
  - 테스트용 더미데이터
 - **src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java**
   - expenditures() : id를 URI에서 추출하여 지출 상세 내용을 반환합니다.
   - search() : 파라미터로 각각의 조건에 맞게 조회를 합니다.
      - 미입력 시 기본값을 설정하도록 하였습니다.
      - 모든 파라미터 미입력시에도 조회가 되도록 구현

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ExpenditureDTO.java**
  - 지출내역 id를 반환합니다. Swagger에서 입력받지 않고 응답용임을 알려주기 위한 AccessMode를 설정했습니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepositoryImpl.java**
  - QueryDsl 구현체로 페이지별 지출 데이터 조회, 총 합계 금액 및 각 카테고리별 합계 금액 추출하는 메서드를 구현하였습니다.
   
   - `searchExpenditure()`: 페이지별 지출 데이터 조회로 동적 쿼리인 BooleanBuilder 객체를 활용해 Pagenation 처리를 합니다.

   - `getTotalAndCategorySum()` : 조건에 맞는 전체 데이터를 조회한 후 총합, 카테고리별 총합을 구해 DTO화 하여 반환합니다.

  - `getCategoryNameH()` : 카테고리 id로 카테고리 한글 이름 추출하는 메서드입니다.
  
   - `createBooleanBuilder()` : 여러 조건을 동적으로 추가할 수 있도록 도와주는 BooleanBuilder 객체를 생성해주는 메서드로, `searchExpenditure, getTotalAndCategorySum 두 곳에서 모두 필요한 중복 로직`을 `하나의 메서드로 분리`하였습니다.
     - 사용자가 카테고리를 입력하지 않으면 전체 데이터가 필요하기에 입력한 경우에만 조건 추가
     - minPrice 및 maxPrice 각 조건 및 상황에 맞게 동적 쿼리 생성
        - goe : 이상 / loe : 이하

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - search : 단건 조회 / 목록 조회를 매개변수로 구분하여 각각 구현하였습니다.
   

#### DTO 객체 설명
- CategorySum : 각 카테고리별 총합을 나타낼 때 사용되는 DTO 객체입니다.
  - 카테고리 id, 한글이름, 합계액

- SearchRequestDTO : 목록 조회 API 파라미터로 받은 데이터 DTO

- SearchResult : 최종 목록 반환 DTO로 아래의 정보를 포함합니다.
  - 총 합계 지출액, 카테고리별 지출액, 지출 항목 페이징 리스트

- TotalAndCategorySumDTO : QueryDSL Repository에서 총 합계액과 카테고리별 합계액 전달하는 DTO객체

## 📷 스크린샷

## 👀 기타
