### PR TITLE
[Feat] 오늘 사용 예산 추천 기능

### DIFF
--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -117,4 +117,12 @@ public class ApiV1ExpenditureController {
 		RsData rsRemaining = expenditureService.reaminingBudget(user.getUsername());
 		return rsRemaining;
 	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("/recommend")
+	@Operation(summary = "오늘의 지출 금액 추천 API")
+	public RsData recommendBudget(@AuthenticationPrincipal User user) {
+		RsData rsRecommend = expenditureService.recommendBudget(user.getUsername());
+		return rsRecommend;
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/RecommendDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/RecommendDTO.java
@@ -1,0 +1,24 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendDTO {
+			// 1. 지출 목표량 남은 금액 : 목표 - 현재까지 사용한 총 금액
+			// 2. 오늘 사용할 총액 : 지출 목표량 남은 금액 / 말일까지 남은 일
+			// 3. 각 카테고리별 추천액 : 각 카테고리별 남은 금액 총액 / 말일까지 남은일
+			// 4. 응원 메세지
+	private Integer totalRemainingPrice;
+	private Integer todayTotalPrice;
+	private List<CategorySum> recommendPriceEachCategory;
+	private String message;
+
+}

--- a/src/main/java/com/wanted/moneyway/standard/util/Ut.java
+++ b/src/main/java/com/wanted/moneyway/standard/util/Ut.java
@@ -2,6 +2,7 @@ package com.wanted.moneyway.standard.util;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -41,6 +42,10 @@ public class Ut {
 		public static LocalDate getEndOfMonth(LocalDate date) {
 			YearMonth yearMonth = YearMonth.from(date);
 			return yearMonth.atEndOfMonth();
+		}
+
+		public static int getDaysBetweenDates(LocalDate date1, LocalDate date2) {
+			return (int) ChronoUnit.DAYS.between(date1, date2) + 1;
 		}
 
 	}

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -258,4 +258,31 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.data.remainingPriceByCategoy[0].categoryName").value("식비"))
 			.andExpect(jsonPath("$.data.remainingPriceByCategoy[0].spending").value(390000));
 	}
+
+	/*
+		남은 금액 / 말일까지 남은 일수로 계산하여 결과를 잘 반환하는지 테스트합니다.
+		실제로는 1일별 사용 추천액을 테스트에 넣어야 하지만, 테스트를 수행하는 시점에 따라서 추천 금액이 달라지기에
+		총 금액과 메세지만 테스트합니다.
+	 */
+	@Test
+	@DisplayName("GET /api/v1/expenditure/recommend 는 오늘 사용할 예산을 추천해준다.")
+	void t9() throws Exception {
+		// "cheorhyeon"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("cheorhyeon");
+		token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/recommend")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("금일 지출액 추천 성공"))
+			.andExpect(jsonPath("$.data.totalRemainingPrice").value(870000));
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #20 

### 📑 개요
- 오늘 사용 예산을 추천합니다.
- 남은 예산 / 오늘~말일 까지 남은일 수 기반으로 추천합니다.
- 예산 남아있는 현황 각 케이스별 응원 메세지를 담아 출력합니다.

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java**
  - URI 엔드포인트 지정
 
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/RecommendDTO.java**
  - 추천 결과 응답 DTO 객체로  아래 내용을 담습니다.
    - 	지출 목표량 남은 금액 : 목표 - 현재까지 사용한 총 금액
    - 	오늘 사용할 총액 : 지출 목표량 남은 금액 / 말일까지 남은 일
    - 	각 카테고리별 추천액 : 각 카테고리별 남은 금액 총액 / 말일까지 남은일
    - 	응원 메세지 

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - recommendBudget : 금일 사용 가능한 예산을 추천해주는 메서드로 DTO객체에 들어갈 정보를 추출하여 객체를 생성하여 반환합니다.
      - message 종류
      - Case 1 : 지출 목표량 남은 금액 자체가 초과한 경우 메세지로 "목표한 예산을 초과하였으니 최대한 절약하며 하루를 보내봅시다!" 출력
     - Case 2 : 각 카테고리별 추천액 중 초과한 예산이 있을 경우 "해당 카테고리 분야의 사용할 수 있는 예산이 없네요. 금일 사용할 총액 이내에서 충당해도 좋으니 절약하는 하루를 보내봅시다!" 출력
     - 위 두 경우가 아닌 경우 "절약하는 하루 보내세요!" 출력

- **src/main/java/com/wanted/moneyway/standard/util/Ut.java**
  - 두 날짜의 차이를 반환하는 유틸리티성 메서드로, 만일 두 날짜가 동일할 시 1일이 반환되도록 +1하여 리턴합니다.

- **src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java**
  - 오늘 날짜 ~ 말일의 날짜 차이를 통해 남은 일수를 계산하고 금액을 추천하기에, 테스트하는 시점마다 테스트 데이터를 수정할 필요가 있습니다.
   - 따라서 총 금액과 메세지만 테스트하였습니다.

## 📷 스크린샷

## 👀 기타
