### PR TITLE
[Feat] 오늘 지출 내역과 각 카테고리별 지출 위험도 안내 기능 구현

### DIFF
--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -136,4 +136,12 @@ public class ApiV1ExpenditureController {
 		RsData rsModify = expenditureService.modifyExpenditure(user.getUsername(), expenditureDTO, id);
 		return rsModify;
 	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping ("/today")
+	@Operation(summary = "오늘 지출 내역 안내 API")
+	public RsData today(@AuthenticationPrincipal User user) {
+		RsData rsToday = expenditureService.getToday(user.getUsername());
+		return rsToday;
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/BudgetCalculationResult.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/BudgetCalculationResult.java
@@ -1,0 +1,18 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BudgetCalculationResult {
+	private Integer diffTotal;
+	private Integer todayTotal;
+	private List<CategorySum> diffCategorySumList;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySumWithDanger.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySumWithDanger.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class CategorySumWithDanger {
 	private Long categoryId;
 	private String categoryName;
-	private Integer todaySpending;
 	private Integer recommendTodaySpending;
+	private Integer todaySpending;
 	private Double danger;
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySumWithDanger.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySumWithDanger.java
@@ -1,0 +1,18 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CategorySumWithDanger {
+	private Long categoryId;
+	private String categoryName;
+	private Integer todaySpending;
+	private Integer recommendTodaySpending;
+	private Double danger;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TodayDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TodayDTO.java
@@ -1,0 +1,18 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TodayDTO {
+	private Integer recommendTodayTotalPrice;
+	private Integer todayTotalPrice;
+	private List<CategorySumWithDanger> categorySumWithDanger;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/ExpenditureRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/ExpenditureRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 
-public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, CustomExpenditureRepository  {
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, CustomExpenditureRepository {
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -314,4 +314,31 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.msg").value("지출 내역 변경 성공"))
 			.andExpect(jsonPath("$.data.spendingPrice").value(40000));
 	}
+
+	/*
+		오늘 지출한 총액, 카테고리별 금액을 오늘 추천해준 금액과 비교하는 결과를 반환합니다.
+		실제로는 차이 금액과 위험도로 테스트를 해야하지만, 테스트를 수행하는 시점에 따라서 추천 금액과 위험도가 달라지기 때문에
+		오늘 지출한 총 금액과 메세지만 테스트합니다.
+ 	*/
+	@Test
+	@DisplayName("GET /api/v1/expenditure/today 는 오늘 지출 내역과 위험도를 알려준다.")
+	void t11() throws Exception {
+		// "cheorhyeon"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("cheorhyeon");
+		token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/today")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("오늘 지출 내역과 위험도 반환 성공"))
+			.andExpect(jsonPath("$.data.todayTotalPrice").value(430000));
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️관련 이슈[#]
close #24 
### 📑 개요
- 오늘 지출 내역과 추천 금액을 기준으로 위험도를 반환합니다.
- 오늘 지출 추천 금액과 실제 사용한 예산을 비교해야 하기에 `오늘 사용 가능한 예산 추천 로직이 중복`되어 메서드화 하는 리팩토링을 진행하였습니다.

###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java**
  - API 요청 정의

-  **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/BudgetCalculationResult.java**
  - 예산 추천액을 반환하는 DTO Class를 정의합니다.  
    - 사용할 수 있는 총 금액(목표 - 현재까지 사용한 총 금액) / 오늘 사용할 총액 추천 / 각 카테고리별 추천액

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategorySumWithDanger.java**
  -  각 카테고리별 오늘 실제 사용액, 추천액, 위험도를 담아 반환하는 DTO Class 입니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TodayDTO.java**
  - 최종 API 요청의 응답 DTO 객체입니다. 
    - 오늘 추천 총액 / 실제 사용한 금액 총액 / 각 카테고리별 위험도 등 정보

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - searchRequestDTO : 1일부터 오늘 전날까지 지출한 금액을 추출하기 위해 today.minusDays(1)로 수정하였습니다.
    - 전날까지 지출 내역만 봐야 오늘꺼를 추천할 수 있어 수정

  - calculateBudget() : 기존 코드 메서드화(예산 계획, 현재까지 지출액, 남은일자를 매개변수로 받아 오늘의 추천 지출을 반환합니다.)
   - 오늘 지출 내역 조회 시 추천한 금액 대비 사용량을 계산하기 위해 중복 로직 불가피
     - 따라서 공통 로직을 메서드화 하여 중복 최소화 하기 위함

  - getToday() : 오늘 지출 내역을 반환(추천액, 실제 사용액, 각 카테고리별 위험도)
  - todayResultWithDangerList를 구할 때 for문 로직 설명
       - 오늘 사용한 예산 리스트인 todayPriceEachCategory 추출
       - 예산 계획에 속한 카테고리가 오늘 지출했는지 검사
       - 지출 했다면 실제 사용금액 대비 위험도 계산 / 지출하지 않았다면 위험도 및 지출액 0 설정

- **src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java**
  - 테스트 시 위험도 , 추천액 등 테스트를 해야 하지만, 테스트 실행 시점에 따라 값이 달라집니다.(현재날 ~ 말일 남은 일수로 추천액)
  - 따라서 메세지와 총 사용금액만 테스트 하도록 설계하였습니다.

## 📷 스크린샷
![image](https://github.com/CheorHyeon/MoneyWay/assets/126079049/d8c9934b-5ea4-405e-ae42-95fa91bd204e)

성공 ㅎㅎ
## 👀 기타
