### PR TITLE
[Feat] 지난달 대비 오늘 일자 기준 사용량 통계 데이터 추출 기능 구현

### DIFF
--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -264,6 +264,53 @@ public class NotProd {
 
 			expenditureRepository.saveAll(cheorHyeonExpenditureList);
 
+			/*
+				지난달 소비 더미 데이터 생성
+			 */
+
+			// 비워줘서 객체 재사용
+			cheorHyeonExpenditureList.clear();
+
+			Expenditure ex10 = Expenditure.builder()
+				.member(cheorHyeon)
+				.category(category1)
+				.memo("홍길동과 1차 삼겹살집")
+				.spendingPrice(60_000)
+				.spendDate(LocalDate.now().minusDays(31))
+				.build();
+
+			Expenditure ex11 = Expenditure.builder()
+				.member(cheorHyeon)
+				.category(category1)
+				.memo("홍길동과 2차 포차")
+				.spendingPrice(40_000)
+				.spendDate(LocalDate.now().minusDays(31))
+				.build();
+
+			Expenditure ex12 = Expenditure.builder()
+				.member(cheorHyeon)
+				.category(category2)
+				.memo("빽다방")
+				.spendingPrice(2_000)
+				.spendDate(LocalDate.now().minusDays(32))
+				.build();
+
+			Expenditure ex13 = Expenditure.builder()
+				.member(cheorHyeon)
+				.category(category2)
+				.memo("빽다방")
+				.spendingPrice(4_000)
+				.spendDate(LocalDate.now().minusDays(32))
+				.build();
+
+			cheorHyeonExpenditureList.add(ex10);
+			cheorHyeonExpenditureList.add(ex11);
+			cheorHyeonExpenditureList.add(ex12);
+			cheorHyeonExpenditureList.add(ex13);
+
+			expenditureRepository.saveAll(cheorHyeonExpenditureList);
+
+
 		};
 	}
 }

--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -276,7 +276,7 @@ public class NotProd {
 				.category(category1)
 				.memo("홍길동과 1차 삼겹살집")
 				.spendingPrice(60_000)
-				.spendDate(LocalDate.now().minusDays(31))
+				.spendDate(LocalDate.now().minusMonths(1))
 				.build();
 
 			Expenditure ex11 = Expenditure.builder()
@@ -284,7 +284,7 @@ public class NotProd {
 				.category(category1)
 				.memo("홍길동과 2차 포차")
 				.spendingPrice(40_000)
-				.spendDate(LocalDate.now().minusDays(31))
+				.spendDate(LocalDate.now().minusMonths(1))
 				.build();
 
 			Expenditure ex12 = Expenditure.builder()
@@ -292,7 +292,7 @@ public class NotProd {
 				.category(category2)
 				.memo("빽다방")
 				.spendingPrice(2_000)
-				.spendDate(LocalDate.now().minusDays(32))
+				.spendDate(LocalDate.now().minusMonths(1))
 				.build();
 
 			Expenditure ex13 = Expenditure.builder()
@@ -300,7 +300,7 @@ public class NotProd {
 				.category(category2)
 				.memo("빽다방")
 				.spendingPrice(4_000)
-				.spendDate(LocalDate.now().minusDays(32))
+				.spendDate(LocalDate.now().minusMonths(1))
 				.build();
 
 			cheorHyeonExpenditureList.add(ex10);

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -144,4 +144,12 @@ public class ApiV1ExpenditureController {
 		RsData rsToday = expenditureService.getToday(user.getUsername());
 		return rsToday;
 	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping ("/statistics/lastmonth")
+	@Operation(summary = "지출 통계 기능 1 - 지난달 대비 총액, 카테고리별 소비율 API")
+	public RsData statisticLastMonth(@AuthenticationPrincipal User user) {
+		RsData rsLastMonth = expenditureService.getLastMonthStatisics(user.getUsername());
+		return rsLastMonth;
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/AMothAgoRatioResult.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/AMothAgoRatioResult.java
@@ -1,0 +1,19 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AMothAgoRatioResult {
+	private Integer currentTotal;
+	private Integer aMonthAgoTotal;
+	private Double totalRatio;
+	private List<CategoryRatio> categoryRatioList;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategoryRatio.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategoryRatio.java
@@ -1,0 +1,18 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CategoryRatio {
+	private Long categoryId;
+	private String categoryName;
+	private Integer aMonthAgoSpending;
+	private Integer todaySpending;
+	private Double compareRatio;
+}


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #26 
### 📑 개요
오늘 일자 기준 지난달 지출과 비교할 수 있는 API를 구현합니다.

###  🧷 변경사항
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/AMothAgoRatioResult.java**
  - 1달 전 소비와 비교하여 사용한 총액, 각 카테로기별 비율을 담는 DTO 객체를 정의합니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/CategoryRatio.java**
  - 각 카테고리별 지난달 사용 금액, 이번달 사용 금액, 비율을 저장하는 DTO 객체를 정의합니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - getLastMonthStatisics() : 오늘 지출 내역을 지난달 대비 총액, 카테고리별 소비율을 반환하는 메서드
     - 1달전 지출 확인 / 이번달 지출 확인 후 각각의 데이터의 비율을 구합니다.
    - 이후 알맞은 DTO 객체로 변환하고 저장하여 RsData 형태로 반환합니다.

- **src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java**
  - 총 3가지 테스트케이스를 구현하였습니다.
    - case 1 : 총액 및 비율
    - case 2 : 카테고리별 비율
    - case 3 : 이번달 신규 카테고리의 경우 비율 없이 금액만 표시

## 📷 스크린샷
![image](https://github.com/CheorHyeon/MoneyWay/assets/126079049/475862e0-cef3-4a69-8eef-91926a4ed9b6)

## 👀 기타
