### PR TITLE
[Feat] 7일전 총 지출액과 오늘 지출액 비교 기능 구현

### DIFF
--- a/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
+++ b/src/main/java/com/wanted/moneyway/base/initData/NotProd.java
@@ -310,6 +310,37 @@ public class NotProd {
 
 			expenditureRepository.saveAll(cheorHyeonExpenditureList);
 
+			/*
+				지난주 소비 더미 데이터 생성
+				테스트에 사용하지 않는 새로운 유저 활용
+			 */
+
+			List<Expenditure> user3ExpenditureList = new ArrayList<>();
+
+			for(int i=0; i<10; i++) {
+				Expenditure user3PreWeekExpenditureTest = Expenditure.builder()
+					.member(user3)
+					.category(category1)
+					.memo("1주일 전 테스트 식비" + i)
+					.spendingPrice(10_000)
+					.spendDate(LocalDate.now().minusDays(7))
+					.build();
+
+				Expenditure user3TodayExpenditureTest = Expenditure.builder()
+					.member(user3)
+					.category(category1)
+					.memo("오늘 테스트 식비" + i)
+					.spendingPrice(20_000)
+					.spendDate(LocalDate.now())
+					.build();
+
+				user3ExpenditureList.add(user3PreWeekExpenditureTest);
+				user3ExpenditureList.add(user3TodayExpenditureTest);
+			}
+
+			expenditureRepository.saveAll(user3ExpenditureList);
+
+
 
 		};
 	}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -152,4 +152,12 @@ public class ApiV1ExpenditureController {
 		RsData rsLastMonth = expenditureService.getLastMonthStatisics(user.getUsername());
 		return rsLastMonth;
 	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping ("/statistics/lastweek")
+	@Operation(summary = "지출 통계 기능 2 - 7일전 지출 대비 지출 총액 비교 API")
+	public RsData statisticLastWeek(@AuthenticationPrincipal User user) {
+		RsData rsLastWeek = expenditureService.getLastWeekStatisics(user.getUsername());
+		return rsLastWeek;
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/AWeekAgoRatioRequest.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/AWeekAgoRatioRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AWeekAgoRatioRequest {
+	private Integer todayTotal;
+	private Integer aWeekAgoTotal;
+	private Double totalRatio;
+}

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -423,4 +423,31 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.data.categoryRatioList[3].amonthAgoSpending").value(0))
 			.andExpect(jsonPath("$.data.categoryRatioList[3].compareRatio").isEmpty());
 	}
+
+	/*
+		7일전 지출과 오늘 지출 총액을 비교한 결과를 반환합니다.
+	 */
+	@Test
+	@DisplayName("GET /api/v1/expenditure/statistics/lastweek 는 7일전 지출과 오늘 지출을 비교합니다.")
+	void t13() throws Exception {
+		// "user3"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user3");
+		token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/statistics/lastweek")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("지난 요일과 총액 비교 성공"))
+			.andExpect(jsonPath("$.data.todayTotal").value(200000))
+			.andExpect(jsonPath("$.data.totalRatio").value(200))
+			.andExpect(jsonPath("$.data.aweekAgoTotal").value(100000));
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #28 
### 📑 개요
7일전 지출액과 오늘 지출액을 비교합니다.
###  🧷 변경사항
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/AWeekAgoRatioRequest.java**
  - 오늘 총 사용액 / 지난주 총 사용액 / 비율을 반환하는 DTO Class를 정의합니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - 7일전 지출 / 오늘 지출 총액을 구합니다.
  - 소수 2번째 자리에서 반올림한 비율을 같이 포함하여 반환합니다.

## 📷 스크린샷
![image](https://github.com/CheorHyeon/MoneyWay/assets/126079049/375baa8d-cfb7-41af-a89c-651248a32883)
- 7일전 사용액과 오늘 날짜 사용액 비교했을 때 200%의 비율 (2배 더 사용)을 의미합니다.

## 👀 기타
기존 테스트케이스에 영향을 주지 않기 위해 user3에 더미데이터 생성 및 테스트 하였습니다.