### PR TITLE
[Feat] 다른 유저 평균 지출액 대비 나의 지출액 비율 반환

### DIFF
--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -160,4 +160,12 @@ public class ApiV1ExpenditureController {
 		RsData rsLastWeek = expenditureService.getLastWeekStatisics(user.getUsername());
 		return rsLastWeek;
 	}
+
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping ("/statistics/otheruser")
+	@Operation(summary = "지출 통계 기능 3 - 다른 유저들 평균 지출액과 나의 지출액 비율 API")
+	public RsData statisticOtherUser(@AuthenticationPrincipal User user) {
+		RsData rsOtherUser = expenditureService.getOtherUserStatisics(user.getUsername());
+		return rsOtherUser;
+	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TotalAndOthersAverage.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TotalAndOthersAverage.java
@@ -1,0 +1,15 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TotalAndOthersAverage {
+	private Integer totalPrice;
+	private Integer othersAverage;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/UserExpenditureComparisonDTO.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/UserExpenditureComparisonDTO.java
@@ -1,0 +1,16 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserExpenditureComparisonDTO {
+	private Integer totalPrice;
+	private Integer othersAverage;
+	private Double expenditureRatio;
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 
 import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndCategorySumDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndOthersAverage;
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 
@@ -11,4 +12,6 @@ public interface CustomExpenditureRepository {
 	Page<Expenditure> searchExpenditure(Member member, SearchRequestDTO searchRequestDTO);
 
 	TotalAndCategorySumDTO getTotalAndCategorySum(Member member, SearchRequestDTO searchRequestDTO);
+
+	TotalAndOthersAverage getTotalAndOthersAverage(Member member, SearchRequestDTO searchRequestDTO);
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepositoryImpl.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepositoryImpl.java
@@ -138,7 +138,8 @@ public class CustomExpenditureRepositoryImpl implements CustomExpenditureReposit
 		Integer total = jpaQueryFactory
 			.select(expenditure.spendingPrice.sum())
 			.from(expenditure)
-			.where(expenditure.spendDate.between(searchRequestDTO.getStartDate(), searchRequestDTO.getEndDate()))
+			.where(expenditure.spendDate.between(searchRequestDTO.getStartDate(), searchRequestDTO.getEndDate()),
+				expenditure.member.eq(targetMember))
 			.fetchOne();
 
 		return TotalAndOthersAverage.builder()

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -674,7 +674,7 @@ public class ExpenditureService {
 		// 오늘 날짜
 		LocalDate today = LocalDate.now();
 
-		// 한달전의 (1일~오늘 일자) 지출 추출용 DTO
+		// 오늘 날짜로 데이터 구할 DTO 객체 생성
 		SearchRequestDTO searchRequestDTO = SearchRequestDTO.builder()
 			.endDate(today)
 			.startDate(today)

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -25,6 +25,8 @@ import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.SearchResult;
 import com.wanted.moneyway.boundedContext.expenditure.dto.TodayDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndCategorySumDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.TotalAndOthersAverage;
+import com.wanted.moneyway.boundedContext.expenditure.dto.UserExpenditureComparisonDTO;
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.expenditure.repository.ExpenditureRepository;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
@@ -664,5 +666,34 @@ public class ExpenditureService {
 
 		return RsData.of("S-1", "지난 요일과 총액 비교 성공", result);
 
+	}
+
+	public RsData getOtherUserStatisics(String userName) {
+		Member member = memberService.get(userName);
+
+		// 오늘 날짜
+		LocalDate today = LocalDate.now();
+
+		// 한달전의 (1일~오늘 일자) 지출 추출용 DTO
+		SearchRequestDTO searchRequestDTO = SearchRequestDTO.builder()
+			.endDate(today)
+			.startDate(today)
+			.build();
+
+		TotalAndOthersAverage totalAndOthersAverage = expenditureRepository.getTotalAndOthersAverage(member,
+			searchRequestDTO);
+
+		Integer userTotal = totalAndOthersAverage.getTotalPrice();
+		Integer otherTotalAvg = totalAndOthersAverage.getOthersAverage();
+
+		UserExpenditureComparisonDTO result = UserExpenditureComparisonDTO
+			.builder()
+			.othersAverage(otherTotalAvg)
+			.totalPrice(userTotal)
+			// 비율 : 나의 지출액 / 다른 사람들 평균 지출액 2번째 자리에서 반올림
+			.expenditureRatio((Math.round(((double)userTotal / otherTotalAvg) * 1000) / 10.0))
+			.build();
+
+		return RsData.of("S-1", "다른 사람들 평균 지출 대비 나의 지출 비율 반환 성공", result);
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -473,8 +473,8 @@ public class ExpenditureControllerTest {
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.msg").value("다른 사람들 평균 지출 대비 나의 지출 비율 반환 성공"))
-			.andExpect(jsonPath("$.data.totalPrice").value(830000))
+			.andExpect(jsonPath("$.data.totalPrice").value(200000))
 			.andExpect(jsonPath("$.data.othersAverage").value(37058))
-			.andExpect(jsonPath("$.data.expenditureRatio").value(2239.7));
+			.andExpect(jsonPath("$.data.expenditureRatio").value(539.7));
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -453,6 +453,8 @@ public class ExpenditureControllerTest {
 
 	/*
 		사용자의 오늘 지출 총액을 다른 사람들의 지출의 평균값과 비교한 결과를 반환합니다.
+		- user1 : 20만원
+		- 다른 사용자 지출액 63만원 -> 평균 31만5천원
  	*/
 	@Test
 	@DisplayName("GET /api/v1/expenditure/statistics/otheruser 는 다른 사람들의 지출 평균과 나이 지출을 비교합니다.")
@@ -474,7 +476,7 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.resultCode").value("S-1"))
 			.andExpect(jsonPath("$.msg").value("다른 사람들 평균 지출 대비 나의 지출 비율 반환 성공"))
 			.andExpect(jsonPath("$.data.totalPrice").value(200000))
-			.andExpect(jsonPath("$.data.othersAverage").value(37058))
-			.andExpect(jsonPath("$.data.expenditureRatio").value(539.7));
+			.andExpect(jsonPath("$.data.othersAverage").value(315000))
+			.andExpect(jsonPath("$.data.expenditureRatio").value( 63.5));
 	}
 }

--- a/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/moneyway/boundedContext/expenditure/ExpenditureControllerTest.java
@@ -450,4 +450,31 @@ public class ExpenditureControllerTest {
 			.andExpect(jsonPath("$.data.totalRatio").value(200))
 			.andExpect(jsonPath("$.data.aweekAgoTotal").value(100000));
 	}
+
+	/*
+		사용자의 오늘 지출 총액을 다른 사람들의 지출의 평균값과 비교한 결과를 반환합니다.
+ 	*/
+	@Test
+	@DisplayName("GET /api/v1/expenditure/statistics/otheruser 는 다른 사람들의 지출 평균과 나이 지출을 비교합니다.")
+	void t14() throws Exception {
+		// "user3"에 해당하는 사용자 정보를 로드하고 JWT 토큰 생성
+		Member member = memberService.get("user1");
+		token = jwtProvider.genToken(member.toClaims(), 60 * 60 * 24 * 1);
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/expenditure/statistics/otheruser")
+					.header("Authorization", "Bearer " + token) // 생성한 토큰을 헤더에 포함
+			)
+			.andDo(print());
+
+		// Then
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value("다른 사람들 평균 지출 대비 나의 지출 비율 반환 성공"))
+			.andExpect(jsonPath("$.data.totalPrice").value(830000))
+			.andExpect(jsonPath("$.data.othersAverage").value(37058))
+			.andExpect(jsonPath("$.data.expenditureRatio").value(2239.7));
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #30 
### 📑 개요
다른 사용자 지출 평균액과 나의 지출액 총액을 비교하여 반환하는 기능 구현
###  🧷 변경사항
- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/TotalAndOthersAverage.java**
  - 사용자의 오늘 지출한 전체 금액과 다른 사람들의 평균 지출액을 담는 DTO 클래스 입니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/UserExpenditureComparisonDTO.java**
  - 사용자의 오늘 지출한 전체 금액과 다른 사람들의 평균 지출액, 다른 사람 지출액

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/repository/CustomExpenditureRepositoryImpl.java**
  - getTotalAndOthersAverage() : 사용자의 오늘 지출액 총합, 다른 사용자의 오늘 지출액 평균을 반환하는 메서드
      - othersSumPrice : 다른 사용자의 오늘 지출액 총합을 반환합니다. 합계 포함 여부 true인 것들만 반영합니다.
    - othersCount : 오늘 지출액 있는 사용자 수를 구합니다.
 
       - Query DSL : countDistinct() 메서드 활용하여 최종 아래와 같은 쿼리가 발생합니다.
     
       ```MySQL
        select count(distinct E.member_id) 
        FROM expenditure AS E
        where E.member_id != 1
        and E.spend_date = "2023-11-17"
        and E.is_total = b'1';
        ```
    - total : 대상 사용자의 오늘 지출 총액을 구합니다.

- **src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java**
  - 오늘 날짜와 Member 객체를 넘겨 오늘 총 지출액과 다른사람들 지출액  평균을 구해옵니다.
  - 이후 비율 계산하여 DTO객체에 할당한 뒤 RsData 형태로 반환합니다.

## 📷 스크린샷
![image](https://github.com/CheorHyeon/MoneyWay/assets/126079049/2b736fa4-1809-4fea-b83a-fc4cf53ec182)

## 👀 기타
