### PR TITLE
[Refactor] Redis 도입하여 Refresh Token 및 Category 캐시 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
+
+    implementation 'org.springframework.boot:spring-boot-starter-cache' // 스프링 캐시 추상화
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis' // redis 사용
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/moneyway/MoneywayApplication.java
+++ b/src/main/java/com/wanted/moneyway/MoneywayApplication.java
@@ -2,8 +2,10 @@ package com.wanted.moneyway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class MoneywayApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java
+++ b/src/main/java/com/wanted/moneyway/base/jwt/JwtProvider.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import com.wanted.moneyway.standard.util.Ut;

--- a/src/main/java/com/wanted/moneyway/base/redis/RedisService.java
+++ b/src/main/java/com/wanted/moneyway/base/redis/RedisService.java
@@ -1,5 +1,6 @@
 package com.wanted.moneyway.base.redis;
 
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/wanted/moneyway/base/redis/RedisService.java
+++ b/src/main/java/com/wanted/moneyway/base/redis/RedisService.java
@@ -1,0 +1,22 @@
+package com.wanted.moneyway.base.redis;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import com.wanted.moneyway.boundedContext.member.entity.Member;
+import com.wanted.moneyway.boundedContext.member.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+	private final MemberService memberService;
+
+	@Cacheable(value = "Refresh", key = "#targetId")
+	public String getRefreshTokenByCached(long targetId) {
+		Member member = memberService.get(targetId);
+		return member.getRefreshToken();
+	}
+}

--- a/src/main/java/com/wanted/moneyway/base/redis/RedisService.java
+++ b/src/main/java/com/wanted/moneyway/base/redis/RedisService.java
@@ -1,9 +1,13 @@
 package com.wanted.moneyway.base.redis;
 
+import java.util.List;
+
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import com.wanted.moneyway.boundedContext.category.entity.Category;
+import com.wanted.moneyway.boundedContext.category.repository.CategoryRepository;
 import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
 
@@ -15,9 +19,21 @@ public class RedisService {
 
 	private final MemberService memberService;
 
+	private final CategoryRepository categoryRepository;
+
 	@Cacheable(value = "Refresh", key = "#targetId")
 	public String getRefreshTokenByCached(long targetId) {
 		Member member = memberService.get(targetId);
 		return member.getRefreshToken();
+	}
+
+	@Cacheable(value = "CategoryList")
+	public List<Category> getAllCategoriesByCached() {
+		return categoryRepository.findAll();
+	}
+
+	@Cacheable(value = "Category", key = "#categoryId")
+	public Category getCategoryByCached(Long categoryId) {
+		return categoryRepository.findById(categoryId).orElse(null);
 	}
 }

--- a/src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java
@@ -94,12 +94,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
-	private Member getMemberFromToken(String token) throws AuthenticationException {
+	private Member getMemberFromToken(String token){
 		Map<String, Object> claims = jwtProvider.getClaims(token);
-		long id = (int)claims.get("id");
-		Member member = memberService.get(id);
-		if (member == null)
-			throw new AuthenticationException("존재하지 않는 사용자입니다.");
+		Member member = memberService.createByClaims(claims);
 		return member;
 	}
 

--- a/src/main/java/com/wanted/moneyway/boundedContext/category/entity/Category.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/category/entity/Category.java
@@ -2,6 +2,8 @@ package com.wanted.moneyway.boundedContext.category.entity;
 
 import static jakarta.persistence.GenerationType.*;
 
+import java.io.Serializable;
+
 import com.querydsl.core.annotations.QueryEntity;
 
 import jakarta.persistence.Column;
@@ -19,7 +21,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @QueryEntity
-public class Category {
+public class Category implements Serializable {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;

--- a/src/main/java/com/wanted/moneyway/boundedContext/category/service/CategoryService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/category/service/CategoryService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.moneyway.base.redis.RedisService;
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.repository.CategoryRepository;
@@ -15,9 +16,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CategoryService {
-	private final CategoryRepository categoryRepository;
+	private final RedisService redisService;
 	public RsData<List<Category>> getAll() {
-		List<Category> allCategories = categoryRepository.findAll();
+		// 캐시 활용
+		List<Category> allCategories = redisService.getAllCategoriesByCached();
 
 		if(allCategories.isEmpty()){
 			return RsData.of("F-1", "등록된 카테고리가 없습니다.");
@@ -27,6 +29,7 @@ public class CategoryService {
 	}
 
 	public Category get(Long categoryId) {
-		return categoryRepository.findById(categoryId).get();
+		// 캐시 활용
+		return redisService.getCategoryByCached(categoryId);
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicUpdate
 public class Member {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
@@ -91,4 +91,11 @@ public class MemberService {
 	public Member get(String userName) {
 		return memberRepository.findByUserName(userName).get();
 	}
+
+	public Member createByClaims(Map<String, Object> claims) {
+		return Member.builder()
+			.id((long)(int)claims.get("id"))
+			.userName((String)claims.get("userName"))
+			.build();
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   profiles:
     active: dev
     include: secret
+  cache:
+    type: redis
+  redis:
+    host: 127.0.0.1
+    port: 6379
   h2:
     console:
       enabled: false


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #34 
### 📑 개요
Redis를 도입하여 DB 쿼리를 덜 사용하도록 수정합니다.
###  🧷 변경사항
- **build.gradle**
  - Redis 및 cache 의존성 추가

- **src/main/java/com/wanted/moneyway/MoneywayApplication.java**
  - Cache 기능 켜기

- **src/main/java/com/wanted/moneyway/base/redis/RedisService.java**
  - Redis에서 동작할 메서드들을 모아둔 Service 클래스

   - getRefreshTokenByCached() : 사용자에게 할당된 Refresh Token을 캐싱
     - Refresh Token을 확인하기 위해 DB 쿼리를 보내지 않기 위함
   - getAllCategoriesByCached() : 예산 카테고리 목록을 캐싱
     - 예산 카테고리는 변하지 않는 data로 DB 쿼리를 보내지 않기 위함
   - getCategoryByCached() : 예산 카테고리 각각을 캐싱
     - 예산 지출 저장, 예산 지출 계획 수립 등 예산 가져올 때 캐싱

- **src/main/java/com/wanted/moneyway/base/security/filter/JwtAuthorizationFilter.java**
  - DB 접속을 통해 사용자에게 저장된 Refresh Token을 비교 -> 캐싱된 Refresh Token 과 비교하도록 수정
  - 검증이 되었다면 Member 객체를 생성하여 인증 처리

   - getMemberFromToken() 
    - Access Token 인증 시 토큰에서 claims 추출하여 Member 객체 생성 후 인증 처리
       - DB 쿼리 발생하지 않도록 수정

- **src/main/java/com/wanted/moneyway/boundedContext/category/entity/Category.java**
  - Redis에 사용자 정의 Class 사용하기 위해서는 Serializable 인터페이스를 구현을 해야함
     - Redis는 데이터를 바이트 형태로 저장하기에 캐시 저장할 객체는 **직렬화가 가능해야 하고, 기본 생성자가 있어야 함**
     - Serializable 인터페이스를 구현하는 것은 JVM에게 해당 클래스의 인스턴스가 직렬화 할 수 있다는 것을 JVM에게 알려줌
         - 직렬화 : 객체를 바이트 스트림으로 변환하는 과정
     - 기본 생성자 : @NoArgsConstructor로 이미 구현

- **src/main/java/com/wanted/moneyway/boundedContext/category/service/CategoryService.java**
  - 캐시를 활용해 카테고리 조회하도록 수정

- **src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java**
  - Refresh Token 갱신될 때 Dirty Checking 시 해당 토큰만 update 쿼리 발생하도록 수정

- **src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java**
  - 로그인 시 Refresh Token 갱신하고, 캐싱 값 수정하는 `updateRefreshToken__Cached` 메서드 정의
  - RedisService에 Refresh Token 캐싱 메서드를 정의하면 **RedisService와 MemberService간 순환 참조 발생**
   - 따라서 Spring IoC인 ApplicationContext에서 `MemberService의 프록시 객체를 주입`받아 `updateRefreshToken__Cached 메서드 호출`하도록 설정
   - createByClaims : 토큰에서 추출한 데이터로 Member 객체 생성하여 반환

- **src/main/resources/application.yml**
  - Redis를 캐시로 사용하겠다 명시 및 위치 지정

## 📷 스크린샷

## 👀 기타
- 상세 설명은 블로그를 참고하세요!
  - [[Spring Boot] Redis 적용기 - 1 JWT Refresh Token 저장 및 갱신](https://velog.io/@puar12/Spring-Redis-%EC%A0%81%EC%9A%A9%EA%B8%B0-1)
  - [[Spring Boot] Redis 적용기 - 2 사용자 정의 Class List로 저장 및 호출](https://velog.io/@puar12/Spring-Boot-Redis-%EC%A0%81%EC%9A%A9%EA%B8%B0-2-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%A0%95%EC%9D%98-Class-List%EB%A1%9C-%EC%A0%80%EC%9E%A5-%EB%B0%8F-%ED%98%B8%EC%B6%9C) 