### PR TITLE
feat : refreshToken 초기화하여 재로그인 유도 기능 구현

### DIFF
--- a/src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java
@@ -1,20 +1,27 @@
 package com.wanted.moneyway.boundedContext.member.controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.wanted.moneyway.base.jwt.JwtProvider;
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.member.DTO.TokenDTO;
 import com.wanted.moneyway.boundedContext.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -28,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "MemberController", description = "회원가입, 로그인처리 컨트롤러")
 public class ApiV1MemberController {
 	private final MemberService memberService;
+	private final JwtProvider jwtProvider;
 
 	@Data
 	public static class SignupRequest {
@@ -65,7 +73,6 @@ public class ApiV1MemberController {
 		private String password;
 	}
 
-
 	@PostMapping("/login")
 	@Operation(summary = "JWT, RT 발급(로그인) API")
 	public RsData<TokenDTO> login(@Valid @RequestBody SignInRequest signInRequest, BindingResult bindingResult) {
@@ -79,6 +86,48 @@ public class ApiV1MemberController {
 		}
 
 		RsData<TokenDTO> rsData = memberService.login(signInRequest.getUsername(), signInRequest.getPassword());
+
+		return rsData;
+	}
+
+	@Data
+	public static class ResetRequest {
+		@NotBlank(message = "삭제하고자 하는 RT를 입력해주세요. 로그인한 본인만 가능합니다.")
+		@Schema(description = "삭제하고자 하는 Refresh Token", example = "wqijkwdqmjklasdklasdklmasdksak")
+		private String refreshToken;
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@DeleteMapping("/reset")
+	@Operation(summary = "RT 초기화", security = {
+		@SecurityRequirement(name = "bearerAuth"),
+		@SecurityRequirement(name = "RefreshToken")
+	})
+	public RsData resetRefreshToken(@Valid @RequestBody ResetRequest resetRequest, BindingResult bindingResult,
+		@AuthenticationPrincipal User user) {
+		// 요청 객체에서 입력하지 않은 부분이 있다면 메세지를 담아서 RsData 객체 바로 리턴
+		if (bindingResult.hasErrors()) {
+			List<String> errorMessages = bindingResult.getAllErrors()
+				.stream()
+				.map(error -> error.getDefaultMessage())
+				.collect(Collectors.toList());
+			return RsData.of("F-1", errorMessages.get(0));
+		}
+
+		Map<String, Object> claimsByRefreshToken = jwtProvider.getClaims(resetRequest.getRefreshToken());
+
+		String getUserNameByRefreshToken = (String)claimsByRefreshToken.get("userName");
+
+		String getUserNameByPrinciple = user.getUsername();
+
+		// 현재 로그인한 사용자의 RT여야 삭제 가능 or 관리자가 특정 토큰 삭제 하려고 할 때 가능
+		if (!getUserNameByPrinciple.equals(getUserNameByRefreshToken)) {
+			if (!getUserNameByPrinciple.equals("admin")) {
+				return RsData.of("F-1", "본인의 Refresh Token만 삭제 가능합니다.");
+			}
+		}
+
+		RsData rsData = memberService.deleteRefreshToken((long)(int)claimsByRefreshToken.get("id"));
 
 		return rsData;
 	}

--- a/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java
@@ -60,4 +60,8 @@ public class Member {
 		result.put("userName", getUserName());
 		return result;
 	}
+
+	public void resetRefreshToken() {
+		this.refreshToken = null;
+	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #36 
### 📑 개요
- Refresh Token이 탈취 되었거나 탈취 의심 시 해당 Refresh Token을 명시적으로 제거하여 사용자가 재로그인 유도로써 보안 강화
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/moneyway/boundedContext/member/controller/ApiV1MemberController.java**
  - resetRefreshToken : 현재 로그인한 사용자에게 RT을 받아서 삭제합니다. 로그인한 사용자 본인 RT가 아니면 삭제가 불가능합니다. admin은 삭제 가능합니다.
- **src/main/java/com/wanted/moneyway/boundedContext/member/entity/Member.java**
  - resetRefreshToken 메서드로 RT를 null로 초기화 합니다.
- src/main/java/com/wanted/moneyway/boundedContext/member/service/MemberService.java
  - deleteRefreshToken : @CacheEvict 어노테이션을 적용하여 Redis 캐싱을 초기화 합니다.
    - beforeInvocation 옵션을 true로 설정하면 삭제하고 메서드가 동작하기에 DB 초기화 하기 전에 메서드가 종료되어 기본값인 false로 설정했습니다.
    - @CacheEvict의 경우 캐싱된 값이 없어도 메서드가 동작하기 때문에 삭제 되었는지 확인이 필요하여 RedisTemplate을 주입받아 값이 있는지 검사하는 isRefreshTokenExists 메서드를 만들어 사용하였습니다.

## 📷 스크린샷

## 👀 기타
