### PR TITLE
feat : 회고록 작성 시 HTML Sanitizer 적용시켜 혹시 모를 XSS 공격 대비

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-cache' // 스프링 캐시 추상화
     implementation 'org.springframework.boot:spring-boot-starter-data-redis' // redis 사용
+
+    implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1") // Sanitizer
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/moneyway/base/service/HtmlSanitizerService.java
+++ b/src/main/java/com/wanted/moneyway/base/service/HtmlSanitizerService.java
@@ -1,0 +1,33 @@
+package com.wanted.moneyway.base.service;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HtmlSanitizerService {
+
+	// 1) 허용할 태그, 속성, URL 스킴을 화이트리스트로 정의
+	private static final PolicyFactory POLICY = new HtmlPolicyBuilder()
+		// 블록 요소
+		.allowElements("p", "div", "ul", "ol", "li", "h1", "h2", "h3", "blockquote")
+		// 인라인 요소
+		.allowElements("span", "strong", "em", "br", "code")
+		// 링크와 이미지
+		.allowElements("a", "img")
+		.allowAttributes("href").onElements("a")
+		.allowAttributes("src", "alt", "width", "height").onElements("img")
+		// href/src 스킴 제한
+		.allowUrlProtocols("http", "https")
+		// 스타일 속성(필요 시)
+		.allowAttributes("style").onElements("span", "p", "div")
+		.toFactory();
+
+	/**
+	 * @param rawHtml 사용자로부터 넘어온 원시 HTML
+	 * @return 안전하게 필터링된 HTML
+	 */
+	public String sanitize(String rawHtml) {
+		return POLICY.sanitize(rawHtml);
+	}
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/controller/ApiV1ExpenditureController.java
@@ -2,6 +2,7 @@ package com.wanted.moneyway.boundedContext.expenditure.controller;
 
 import java.time.LocalDate;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
@@ -17,16 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.wanted.moneyway.base.rsData.RsData;
 import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.ReviewWriteRequest;
 import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.SearchResult;
 import com.wanted.moneyway.boundedContext.expenditure.entity.Expenditure;
 import com.wanted.moneyway.boundedContext.expenditure.service.ExpenditureService;
+import com.wanted.moneyway.boundedContext.member.entity.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -166,5 +170,12 @@ public class ApiV1ExpenditureController {
 	public RsData statisticOtherUser(@AuthenticationPrincipal User user) {
 		RsData rsOtherUser = expenditureService.getOtherUserStatisics(user.getUsername());
 		return rsOtherUser;
+	}
+
+	@PostMapping("/review")
+	@Operation(summary = "한달 회고 작성", description = "한달동안 회고를 작성합니다.")
+	public ResponseEntity<String> reviewWrite(@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid ReviewWriteRequest reviewWriteRequest) {
+		return ResponseEntity.ok(expenditureService.writeReview(userDetails.getMember(), reviewWriteRequest));
 	}
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ReviewWriteRequest.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/dto/ReviewWriteRequest.java
@@ -1,0 +1,14 @@
+package com.wanted.moneyway.boundedContext.expenditure.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ReviewWriteRequest(
+	@Schema(description = "이번달 회고록 제목", example = "4월 총 사용 회고록")
+	@NotBlank(message = "제목은 필수 항목입니다.")
+	String title,
+	@Schema(description = "이번달 회고록 내용", example = "<p> 병원비.. 눈물.. </p>")
+	@NotBlank(message = "본문 내용은 필수 항목입니다.")
+	String content
+) {
+}

--- a/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/expenditure/service/ExpenditureService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.wanted.moneyway.base.rsData.RsData;
+import com.wanted.moneyway.base.service.HtmlSanitizerService;
 import com.wanted.moneyway.boundedContext.category.entity.Category;
 import com.wanted.moneyway.boundedContext.category.service.CategoryService;
 import com.wanted.moneyway.boundedContext.expenditure.dto.AMothAgoRatioResult;
@@ -26,6 +27,7 @@ import com.wanted.moneyway.boundedContext.expenditure.dto.CategorySumWithDanger;
 import com.wanted.moneyway.boundedContext.expenditure.dto.ExpenditureDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.RecommendDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.RemainingDTO;
+import com.wanted.moneyway.boundedContext.expenditure.dto.ReviewWriteRequest;
 import com.wanted.moneyway.boundedContext.expenditure.dto.SearchRequestDTO;
 import com.wanted.moneyway.boundedContext.expenditure.dto.SearchResult;
 import com.wanted.moneyway.boundedContext.expenditure.dto.TodayDTO;
@@ -49,10 +51,9 @@ public class ExpenditureService {
 
 	private final ExpenditureRepository expenditureRepository;
 	private final MemberService memberService;
-
 	private final CategoryService categoryService;
-
 	private final PlanService planService;
+	private final HtmlSanitizerService htmlSanitizerService;
 
 	@Transactional
 	public RsData<Expenditure> create(ExpenditureDTO expenditureDTO, String username) {
@@ -685,5 +686,14 @@ public class ExpenditureService {
 			.build();
 
 		return RsData.of("S-1", "다른 사람들 평균 지출 대비 나의 지출 비율 반환 성공", result);
+	}
+
+	@Transactional
+	public String writeReview(Member member, ReviewWriteRequest reviewWriteRequest) {
+		// 1. 혹시 모를 XSS 공격 대비 화이트리스트로 위험 요소 내용 삭제
+		String sanitizeContent = htmlSanitizerService.sanitize(reviewWriteRequest.content());
+
+		// 2. DB 저장인데 return으로 대체
+		return sanitizeContent;
 	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📑 개요
- 기능을 구현하다 보면 HTML 에디터 or 마크다운 에디터 등 사용하는 경우를 한번쯤 만나게된다.
- 이 경우 물론 React 등 프론트에서 방어를 할 수 있지만, 서버로부터 요청이 어떻게든 악의적으로 오는 경우도 고려를 해야한다.
  - 악의적인 사용자가 postman 등으로 그냥 헤더에 JWT 넣고, 본문 내용에 script 태그 심으면 그냥 털리는거여..

## 구현 방법
- owasp-java-html-sanitizer 이용하여 허용하는 HTML 태그들을 명시적으로 지정하는 화이트리스트 방식 이용
- 허용 불가능한 태그들이 올 경우 해당 내용 삭제시킴

## 📷 스크린샷

### 허용된 태그 입력 시
![image](https://github.com/user-attachments/assets/db3efe8f-18db-4fa7-bf9e-2cb00a154c34)

- 내용이 그대로 반환된다.
  - 실제론 DB 저장이겠지만 단순 반환
![image](https://github.com/user-attachments/assets/1137c15c-ebbb-4630-b8b7-db424f1a0a35)

### 허용되지 않은 태그 등 XSS 공격 패턴 입력 시
![image](https://github.com/user-attachments/assets/441cb315-a7ee-44f4-b477-182b602519b6)

- 해당 태그 자체가 삭제된다.
![image](https://github.com/user-attachments/assets/46f94b57-f770-4f59-a3b8-4b85a064b0f3)

## 👀 기타
[블로그 추가 설명 게시글](https://velog.io/@puar12/HTML-%EC%97%90%EB%94%94%ED%84%B0-%EB%93%B1-%EC%82%AC%EC%9A%A9-%EC%8B%9C-XSS-%EA%B3%B5%EA%B2%A9-%EB%B0%B1%EC%97%94%EB%93%9C%EC%97%90%EC%84%9C%EB%8F%84-%EB%8C%80%EB%B9%84%ED%95%98%EA%B8%B0)