### PR TITLE
준영속 상태 Entity를 직접 사용하여 불필요한 select query 나가던 문제 해결

### DIFF
--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/repository/PlanRepository.java
@@ -8,5 +8,5 @@ import com.wanted.moneyway.boundedContext.member.entity.Member;
 import com.wanted.moneyway.boundedContext.plan.entity.Plan;
 
 public interface PlanRepository extends JpaRepository<Plan, Long>, CustomPlanRespository {
-	List<Plan> findAllByMember(Member member);
+	List<Plan> findAllByMember_Id(Long memberId);
 }

--- a/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
+++ b/src/main/java/com/wanted/moneyway/boundedContext/plan/service/PlanService.java
@@ -17,9 +17,11 @@ import com.wanted.moneyway.boundedContext.plan.entity.Plan;
 import com.wanted.moneyway.boundedContext.plan.repository.PlanRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Transactional(readOnly = true)
+@Slf4j
 @RequiredArgsConstructor
 public class PlanService {
 
@@ -36,7 +38,8 @@ public class PlanService {
 		List<Category> categoryList = searchCategoryRs.getData();
 
 		// 기존에 등록한 계획이 있는지 추출
-		List<Plan> plans = planRepository.findAllByMember(member);
+		// member 객체를 넘길 경우 준영속 상태를 영속화 시키려는 시도를 하기에 불필요 select 쿼리가 나감
+		List<Plan> plans = planRepository.findAllByMember_Id(member.getId());
 		// 있다면 수정 상태 flag 변수
 		boolean isModify = plans.size() > 0;
 
@@ -124,7 +127,7 @@ public class PlanService {
 		사용자 별 등록된 지출 계획 반환 메서드
 	 */
 	public RsData<List<Plan>> getAllByMember(Member member) {
-		List<Plan> allByMember = planRepository.findAllByMember(member);
+		List<Plan> allByMember = planRepository.findAllByMember_Id(member.getId());
 		if(allByMember.isEmpty())
 			return RsData.of("F-1", "설정한 지출 계획이 없습니다. 등록 후 이용해주세요");
 


### PR DESCRIPTION
## 🌿 PR타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

###  🧷 변경사항
- 준영속 상태 Entity를 직접 findBy에 사용해서 불필요하게 select 쿼리 나가던 문제 해결
  -  member.getId로 객체에서 값만 꺼내서 넘기도록 수정

- 상세 설명은 하단 블로그 참조

## 📷 스크린샷

## 👀 기타
- [JPA OSIV false일때 준영속 상태 객체로서 활용할 때 불필요한 select 쿼리 한번 더 나가는 문제 해결](https://velog.io/@puar12/JPA-OSIV-false%EC%9D%BC%EB%95%8C-%EC%A4%80%EC%98%81%EC%86%8D-%EC%83%81%ED%83%9C-%EA%B0%9D%EC%B2%B4%EB%A1%9C%EC%84%9C-%ED%99%9C%EC%9A%A9%ED%95%A0-%EB%95%8C-%EB%B6%88%ED%95%84%EC%9A%94%ED%95%9C-select-%EC%BF%BC%EB%A6%AC-%ED%95%9C%EB%B2%88-%EB%8D%94-%EB%82%98%EA%B0%80%EB%8A%94-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)